### PR TITLE
Dotnet 6 upgrades for EfCore referenced projects and Efcore 6 support

### DIFF
--- a/Carbon.Domain.EntityFrameworkCore.Extensions/Carbon.Domain.EntityFrameworkCore.csproj
+++ b/Carbon.Domain.EntityFrameworkCore.Extensions/Carbon.Domain.EntityFrameworkCore.csproj
@@ -1,10 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
-    <LangVersion>8.0</LangVersion>
-    <Version>2.5.1</Version>
+    <TargetFrameworks>net6.0;net5.0;netstandard2.1</TargetFrameworks>
+    <Version>3.0.0</Version>
     <Description>
+		- 3.0.0
+		* Dotnet 6 and EntityFrameworkCore 6 support added.
 		- 2.5.1
 		*ConnectToSolution method on repositoryBase now allows entities to be removed from any solutions altogether.
 
@@ -39,7 +40,7 @@
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'net6.0'">
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.7" />
@@ -48,6 +49,16 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.7" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.8">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Carbon.Quartz.Migrate.Context/Carbon.Quartz.Migrate.Context.csproj
+++ b/Carbon.Quartz.Migrate.Context/Carbon.Quartz.Migrate.Context.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>1.0.0</Version>
+    <Version>1.2.0</Version>
     <Description>Quartz Persistence handled in this context, if you have persistency use this package</Description>
   </PropertyGroup>
 

--- a/Carbon.Quartz.Migrate.MSSQL/Carbon.Quartz.Migrate.MSSQL.csproj
+++ b/Carbon.Quartz.Migrate.MSSQL/Carbon.Quartz.Migrate.MSSQL.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>1.0.0</Version>
+    <Version>1.2.0</Version>
     <Description>Quartz MSSQL Persistency auto migrator</Description>
   </PropertyGroup>
 

--- a/Carbon.Quartz.Migrate.PostgreSQL/Carbon.Quartz.Migrate.PostgreSQL.csproj
+++ b/Carbon.Quartz.Migrate.PostgreSQL/Carbon.Quartz.Migrate.PostgreSQL.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>1.0.0</Version>
+    <Version>1.2.0</Version>
     <Description>Quartz PostgreSQL Persistency auto migrator</Description>
   </PropertyGroup>
 

--- a/Carbon.Quartz/Carbon.Quartz.csproj
+++ b/Carbon.Quartz/Carbon.Quartz.csproj
@@ -1,11 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <GenerateDocumentationFile>False</GenerateDocumentationFile>
-    <Description>Quartz.NET is a full-featured, open source job scheduling system that can be used from smallest apps to large scale enterprise systems.
+    <Description>1.2.0
+- Added EF Core 6 support
+
+Quartz.NET is a full-featured, open source job scheduling system that can be used from smallest apps to large scale enterprise systems.
 
 This quartz package may be a cumbersome when it is used for the first time. So that, this package wrapped properly to run in Kubernetes without breaking 1-click deployment rules and with HA and resilience.</Description>
   </PropertyGroup>

--- a/Carbon.WebApplication.EntityFrameworkCore/Carbon.WebApplication.EntityFrameworkCore.csproj
+++ b/Carbon.WebApplication.EntityFrameworkCore/Carbon.WebApplication.EntityFrameworkCore.csproj
@@ -1,28 +1,32 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
-    <Version>2.1.0</Version>
-    <Description>2.1.0
- Read-Only Context and Repository added in order to implement CQRS over replicated SQL servers. Simply use AddDatabaseWithReadOnlyReplicaContext method in your startup by passing your readonly context.
+    <TargetFrameworks>net6.0;net5.0;netstandard2.1</TargetFrameworks>
+    <Version>2.2.0</Version>
+    <Description>
+		2.2.0
+		Dotnet 6 and EfCore 6 support added when referenced by Carbon.Domain.EntityFrameworkCore 3.0.0 and Dotnet 6.0
 
-2.0.1
- Postgre and MSSQL healthcheck mismatch fixed
+		2.1.0
+		Read-Only Context and Repository added in order to implement CQRS over replicated SQL servers. Simply use AddDatabaseWithReadOnlyReplicaContext method in your startup by passing your readonly context.
 
-2.0.0 (Unstable - please update to at least 2.0.1)
-Entityframework Core 5 support added
+		2.0.1
+		Postgre and MSSQL healthcheck mismatch fixed
 
-1.4.0  (Unstable - please update to at least 2.0.1)
-	Added health check.
-*** 1.3.0
-Database Seeding Support added, Just create a seeder with IContextSeed interface and use app.SeedDatabase by passing your seeder into this method
+		2.0.0 (Unstable - please update to at least 2.0.1)
+		Entityframework Core 5 support added
 
-*** 1.2.6 Migration Management Changed (Multiple Migration)
-Each Migrations should locate under a seperate class library named with {The API Namespace which uses this migration} +{.{Target EF Name [PostgreSQL, MSSQL]}}    (e.g. Platform360.AssetManagement.API.PostgreSQL, Platform360.AssetManagement.API.MSSQL)
+		1.4.0  (Unstable - please update to at least 2.0.1)
+		Added health check.
+		*** 1.3.0
+		Database Seeding Support added, Just create a seeder with IContextSeed interface and use app.SeedDatabase by passing your seeder into this method
 
-*** PostgreSQL Support Added as of 1.2.0 (Multiple EF Target)
-- Use ConnectionTarget key in your ConnectionStrings Section [postgresql, mssql] of your Configuration.
-- Use AddDatabaseContext Carbon extension while adding your dbContext to use the support mentioned above</Description>
+		*** 1.2.6 Migration Management Changed (Multiple Migration)
+		Each Migrations should locate under a seperate class library named with {The API Namespace which uses this migration} +{.{Target EF Name [PostgreSQL, MSSQL]}}    (e.g. Platform360.AssetManagement.API.PostgreSQL, Platform360.AssetManagement.API.MSSQL)
+
+		*** PostgreSQL Support Added as of 1.2.0 (Multiple EF Target)
+		- Use ConnectionTarget key in your ConnectionStrings Section [postgresql, mssql] of your Configuration.
+		- Use AddDatabaseContext Carbon extension while adding your dbContext to use the support mentioned above</Description>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
 


### PR DESCRIPTION
Carbon.WebApplication.EntityFrameworkCore
2.2.0
  Dotnet 6 and EfCore 6 support added when referenced by Carbon.Domain.EntityFrameworkCore 3.0.0 and Dotnet 6.0

Carbon.Domain.EntityFrameworkCore
- 3.0.0
  Dotnet 6 and EntityFrameworkCore 6 support added.

All Quartz packages supports the packages listed above (1.2.0)