### PR TITLE
quartz and masstransit improvements

### DIFF
--- a/Carbon.MassTransit/AsyncReqResp/Events/RequestCarrierRequest.cs
+++ b/Carbon.MassTransit/AsyncReqResp/Events/RequestCarrierRequest.cs
@@ -4,13 +4,20 @@ namespace Carbon.MassTransit.AsyncReqResp.Events
 {
     public class RequestCarrierRequest : IRequestCarrierRequest
     {
-        public RequestCarrierRequest(Guid correlationId, string integrationBody)
+        public RequestCarrierRequest(Guid correlationId, string requestBody)
         {
             CorrelationId = correlationId;
-            RequestBody = integrationBody;
+            RequestBody = requestBody;
+            OriginatedRequestTime = DateTime.UtcNow;
+        }
+
+        public RequestCarrierRequest(Guid correlationId, string requestBody, DateTime originatedRequestTime) : this(correlationId, requestBody)
+        {
+            OriginatedRequestTime = originatedRequestTime;
         }
 
         public Guid CorrelationId { get; set; }
         public String RequestBody { get; set; }
+        public DateTime OriginatedRequestTime { get; set; }
     }
 }

--- a/Carbon.MassTransit/Carbon.MassTransit.csproj
+++ b/Carbon.MassTransit/Carbon.MassTransit.csproj
@@ -3,7 +3,10 @@
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<Version>3.5.2</Version>
-		<Description>      3.5.0
+		<Description>     3.5.2
+     - Minor fixes
+     - Request Response Async Pattern responder can respond from anywhere thanks to bus 
+     3.5.0
       - Request-Response Async Pattern introduced
       3.4.0
       - Masstransit upgraded to latest 7.x.x version

--- a/Carbon.MassTransit/Carbon.MassTransit.csproj
+++ b/Carbon.MassTransit/Carbon.MassTransit.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
-		<Version>3.5.1</Version>
+		<Version>3.5.2</Version>
 		<Description>      3.5.0
       - Request-Response Async Pattern introduced
       3.4.0

--- a/Carbon.Quartz/Carbon.Quartz.csproj
+++ b/Carbon.Quartz/Carbon.Quartz.csproj
@@ -3,9 +3,14 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
     <GenerateDocumentationFile>False</GenerateDocumentationFile>
-    <Description>1.2.0
+    <Description>1.3.0
+- Job Delete added to service
+- QuartzService auto registered when AddQuartzScheduler used
+- Scheduler now can be retrieved for purpose of raw Quartz usage instead of QuartzService based usage
+
+1.2.0
 - Added EF Core 6 support
 
 Quartz.NET is a full-featured, open source job scheduling system that can be used from smallest apps to large scale enterprise systems.

--- a/Carbon.Quartz/IQuartzClusterableService.cs
+++ b/Carbon.Quartz/IQuartzClusterableService.cs
@@ -13,5 +13,9 @@ namespace Carbon.Quartz
         Task ClearAllJobsExceptFor(List<string> excludingJobKeyList);
         Task AddAndStartClusterableCustomJob<TJob>(string jobName, object jobData, ITrigger trigger)
              where TJob : IJob;
+
+        Task DeleteJob(string jobName);
+
+        Task<IScheduler> GetCurrentScheduler();
     }
 }

--- a/Carbon.Quartz/QuartzService.cs
+++ b/Carbon.Quartz/QuartzService.cs
@@ -98,6 +98,18 @@ namespace Carbon.Quartz
         }
 
         /// <summary>
+        /// Deletes a job with the given name
+        /// </summary>
+        /// <param name="jobName"></param>
+        /// <returns></returns>
+        public async Task DeleteJob(string jobName)
+        {
+            _scheduler = await getRelatedScheduler();
+            JobKey jobKey = new JobKey(jobName);
+            await _scheduler.DeleteJob(jobKey);
+        }
+
+        /// <summary>
         /// Clears all the unused jobs excluding with a given job key list. Useful when you don't know scheduled jobs at an earlier time, and keep the ones you want
         /// </summary>
         /// <param name="excludingJobKeyList">Jobs to keep</param>
@@ -161,6 +173,11 @@ namespace Carbon.Quartz
                 Console.WriteLine(ex.Message);
                 throw new Exception(ex.Message, ex);
             }
+        }
+
+        public async Task<IScheduler> GetCurrentScheduler()
+        {
+            return await this.getRelatedScheduler();
         }
     }
 }

--- a/Carbon.Quartz/QuartzServiceBuilder.cs
+++ b/Carbon.Quartz/QuartzServiceBuilder.cs
@@ -21,6 +21,7 @@ namespace Carbon.Quartz
             if (maxConcurrency > 10)
                 maxConcurrency = 10;
             // base configuration from appsettings.json
+            services.AddScoped<IQuartzClusterableService, QuartzService>();
 
             services.Configure<QuartzOptions>(k => configuration.GetSection(QuartzConstants.Quartz));
 


### PR DESCRIPTION
Carbon.MassTransit
     3.5.2
     - Minor fixes
     - Request Response Async Pattern responder can respond from anywhere thanks to bus 
 
Carbon.Quartz
    1.3.0
     - Job Delete added to service
     - QuartzService auto registered when AddQuartzScheduler used
     - Scheduler now can be retrieved for purpose of raw Quartz usage instead of QuartzService based usage