### PR TITLE
Carbon.Domain.Messages nuget package updated

### DIFF
--- a/Carbon.WebApplication.SolutionService/Carbon.WebApplication.SolutionService.csproj
+++ b/Carbon.WebApplication.SolutionService/Carbon.WebApplication.SolutionService.csproj
@@ -2,8 +2,11 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <Version>2.7.0</Version>
-    <Description>-2.7.0
+    <Version>2.7.1</Version>
+    <Description>
+-2.7.1
+- Carbon.Domain.Messages updated from 1.8.0 to 1.9.18 for Solution model Uri prop
+-2.7.0
 - Critical bug fixed for Directory separator char to specific platform (Windows,Linux)
 -2.6.0
 - Critical bug fixed for SolutionRegistration when there is no default MassTransit usage
@@ -32,15 +35,15 @@ Supports Masstransit 7.1.x and Carbon.MassTransit 3.0.2
 
 -1.0.23
  Supports MassTransit  6.2.3 and Carbon.MassTransit 2.0.8</Description>
-    <AssemblyVersion>2.6.0</AssemblyVersion>
-    <FileVersion>2.6.0</FileVersion>
+    <AssemblyVersion>2.7.1</AssemblyVersion>
+    <FileVersion>2.7.1</FileVersion>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.12" />
-    <PackageReference Include="Carbon.Domain.Messages" Version="1.8.0" />
+    <PackageReference Include="Carbon.Domain.Messages" Version="1.9.18" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Carbon.Domain.Messages updated from 1.8.0 to 1.9.18 for Solution model Uri prop