### PR TITLE
Carbon.Redis Serializer Changes

### DIFF
--- a/Carbon.Redis/Abstractions/CarbonContentSerializationType.cs
+++ b/Carbon.Redis/Abstractions/CarbonContentSerializationType.cs
@@ -1,6 +1,6 @@
 ﻿namespace Carbon.Caching.Abstractions
 {
-    public enum Serialization
+    public enum CarbonContentSerializationType
     {
         BinaryFormatter = 0,
         Json = 1,

--- a/Carbon.Redis/Abstractions/ICarbonCache.cs
+++ b/Carbon.Redis/Abstractions/ICarbonCache.cs
@@ -10,6 +10,5 @@ namespace Carbon.Caching.Abstractions
         int GetRedisDatabaseNumber();
         RedLockFactory GetRedLockFactory();
         IDatabase GetDatabase();
-
     }
 }

--- a/Carbon.Redis/Abstractions/ICarbonCacheExtensions.cs
+++ b/Carbon.Redis/Abstractions/ICarbonCacheExtensions.cs
@@ -15,7 +15,7 @@ namespace Carbon.Caching.Abstractions
         {
             if (PreferredSerializationType == Serialization.BinaryFormatter)
             {
-                Console.WriteLine(SerializationType + " is obsolete, handle with care or consider changing it!");
+                Console.WriteLine(PreferredSerializationType + " is obsolete, handle with care or consider changing it!");
                 SerializationType = PreferredSerializationType;
             }
             else if (PreferredSerializationType == Serialization.Json)

--- a/Carbon.Redis/Abstractions/ICarbonCacheExtensions.cs
+++ b/Carbon.Redis/Abstractions/ICarbonCacheExtensions.cs
@@ -9,20 +9,20 @@ namespace Carbon.Caching.Abstractions
 {
     public static class ICarbonCacheExtensions
     {
-        private static Serialization SerializationType { get; set; }
+        private static CarbonContentSerializationType SerializationType { get; set; }
 
-        public static void SetSerializationType(Serialization PreferredSerializationType)
+        public static void SetSerializationType(CarbonContentSerializationType PreferredSerializationType)
         {
-            if (PreferredSerializationType == Serialization.BinaryFormatter)
+            if (PreferredSerializationType == CarbonContentSerializationType.BinaryFormatter)
             {
                 Console.WriteLine(PreferredSerializationType + " is obsolete, handle with care or consider changing it!");
                 SerializationType = PreferredSerializationType;
             }
-            else if (PreferredSerializationType == Serialization.Json)
+            else if (PreferredSerializationType == CarbonContentSerializationType.Json)
             {
                 SerializationType = PreferredSerializationType;
             }
-            else if (PreferredSerializationType == Serialization.Protobuf)
+            else if (PreferredSerializationType == CarbonContentSerializationType.Protobuf)
             {
                 throw new NotImplementedException("Protobuf serialization is not implemented yet!");
             }

--- a/Carbon.Redis/Abstractions/ICarbonCacheExtensions.cs
+++ b/Carbon.Redis/Abstractions/ICarbonCacheExtensions.cs
@@ -18,7 +18,7 @@ namespace Carbon.Caching.Abstractions
                 options = options.SetSlidingExpiration(period);
             }
 
-            instance.Set(key, content.ToByteArray(), options);
+            instance.Set(key, content.ToByteArraySafe(), options);
         }
 
         public static void Set<T>(this ICarbonCache instance, string key, T content)
@@ -30,7 +30,7 @@ namespace Carbon.Caching.Abstractions
         {
             var value = instance.Get(key);
 
-            return value?.FromByteArray<T>();
+            return value?.FromByteArraySafe<T>();
         }
 
         public static void SetMultiKey<T>(this ICarbonCache instance, IList<string> keys, T content, TimeSpan period)
@@ -54,7 +54,7 @@ namespace Carbon.Caching.Abstractions
         {
             var value = await instance.GetAsync(key, token).ConfigureAwait(false);
 
-            return value?.FromByteArray<T>();
+            return value?.FromByteArraySafe<T>();
         }
 
         public static async Task<T> GetAsync<T>(this ICarbonCache instance, string key, Func<Task<T>> setMethodIfNotExists, CancellationToken token = default(CancellationToken), TimeSpan timeSpan = default(TimeSpan), bool isSlidingExpiration = true) where T : class
@@ -67,7 +67,7 @@ namespace Carbon.Caching.Abstractions
                 return result;
             }
 
-            return value?.FromByteArray<T>();
+            return value?.FromByteArraySafe<T>();
         }
 
 
@@ -90,7 +90,7 @@ namespace Carbon.Caching.Abstractions
                     options = options.SetAbsoluteExpiration(period);
             }
 
-            await instance.SetAsync(key, content.ToByteArray(), options, token).ConfigureAwait(false);
+            await instance.SetAsync(key, content.ToByteArraySafe(), options, token).ConfigureAwait(false);
         }
 
         public static async Task SetMultiKeyAsync<T>(this ICarbonCache instance, IList<string> keys, T content)

--- a/Carbon.Redis/Abstractions/ICarbonCacheExtensions.cs
+++ b/Carbon.Redis/Abstractions/ICarbonCacheExtensions.cs
@@ -77,15 +77,14 @@ namespace Carbon.Caching.Abstractions
 
         public static async Task<T> GetAsync<T>(this ICarbonCache instance, string key, Func<Task<T>> setMethodIfNotExists, CancellationToken token = default(CancellationToken), TimeSpan timeSpan = default(TimeSpan), bool isSlidingExpiration = true) where T : class
         {
-            var value = await instance.GetAsync(key, token).ConfigureAwait(false);
+            var value = await instance.GetAsync<T>(key, token).ConfigureAwait(false);
             if (value == null)
             {
                 T result = await setMethodIfNotExists();
                 await instance.SetAsync(key, result, token, timeSpan, isSlidingExpiration);
                 return result;
             }
-
-            return value?.FromByteArray<T>(SerializationType);
+            return value;
         }
 
 

--- a/Carbon.Redis/Abstractions/Serialization.cs
+++ b/Carbon.Redis/Abstractions/Serialization.cs
@@ -1,0 +1,9 @@
+﻿namespace Carbon.Caching.Abstractions
+{
+    public enum Serialization
+    {
+        BinaryFormatter = 0,
+        Json = 1,
+        Protobuf = 2
+    }
+}

--- a/Carbon.Redis/Carbon.Redis.csproj
+++ b/Carbon.Redis/Carbon.Redis.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <Version>2.0.1-preview</Version>
+    <Version>2.1.0-preview</Version>
     <Description>2.0.0-preview
   Enables you to use CarbonRedisCache Helper in your services to access more extended methods and capabilities (i.e. RedLock, Redis PubSub etc.) and make the legacy apis compatible with this package
   Handle with care while using this Helper extension methods as it contains binaryformatters which are obsoleted as of dotnet 5, either allow this feature in your csproj or do not use dotnet 5 and greater
@@ -18,7 +18,7 @@
 - Scan Keys And Remove By Pattern</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <AssemblyVersion>2.0.0</AssemblyVersion>
+    <AssemblyVersion>2.1.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -29,8 +29,8 @@
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="6.0.10" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="RedLock.net" Version="2.3.2" />
+    <PackageReference Include="System.Text.Json" Version="6.0.6" />
   </ItemGroup>
 
 </Project>

--- a/Carbon.Redis/Carbon.Redis.csproj
+++ b/Carbon.Redis/Carbon.Redis.csproj
@@ -2,8 +2,15 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <Version>2.1.0-preview</Version>
-    <Description>2.0.0-preview
+    <Version>2.1.3-preview</Version>
+    <Description>2.1.3- preview
+Carbon.Redis JSON binary serializer added on the top of binary formatter serializer which is unsupported as of dotnet 5. Simply use static method ICarbonCacheExtensions.SetSerializationType as desired serialization type which defaults to binaryformatter.
+
+If you try to get binaryformatter serialized keys via json binary serializer from redis, you will receive default value (such as null). At that moment, remove the existing key, and add the new one with the new serializer, or use set to replace it.
+
+System.Text.Json (faster) is used as master serializer/deserializer replacing Newtonsoft.Json. This may require to add [Serializable] tag over your objects, make sure you consider it!
+
+2.0.0-preview
   Enables you to use CarbonRedisCache Helper in your services to access more extended methods and capabilities (i.e. RedLock, Redis PubSub etc.) and make the legacy apis compatible with this package
   Handle with care while using this Helper extension methods as it contains binaryformatters which are obsoleted as of dotnet 5, either allow this feature in your csproj or do not use dotnet 5 and greater
   BinaryFormatters will migrate to JsonSerializers or other serializations at incoming versions
@@ -18,7 +25,7 @@
 - Scan Keys And Remove By Pattern</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <AssemblyVersion>2.1.0</AssemblyVersion>
+    <AssemblyVersion>2.1.3</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Carbon.Redis/Carbon.Redis.csproj
+++ b/Carbon.Redis/Carbon.Redis.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <Version>2.0.0-preview</Version>
+    <Version>2.0.1-preview</Version>
     <Description>2.0.0-preview
   Enables you to use CarbonRedisCache Helper in your services to access more extended methods and capabilities (i.e. RedLock, Redis PubSub etc.) and make the legacy apis compatible with this package
   Handle with care while using this Helper extension methods as it contains binaryformatters which are obsoleted as of dotnet 5, either allow this feature in your csproj or do not use dotnet 5 and greater

--- a/Carbon.Redis/Extensions/CarbonRedisCache.cs
+++ b/Carbon.Redis/Extensions/CarbonRedisCache.cs
@@ -13,7 +13,6 @@ namespace Carbon.Caching.Redis
         private readonly RedLockFactory _redlockFactory; 
         private readonly IServer _redisServer;
         private ConnectionMultiplexer _existingConnectionMultiplexer;
-
         public delegate void OnExpiredHandler(string tagName);
         public static event OnExpiredHandler OnExpired;
 
@@ -100,5 +99,7 @@ namespace Carbon.Caching.Redis
         {
             return _existingConnectionMultiplexer.GetDatabase();
         }
+
+        
     }
 }

--- a/Carbon.Redis/Extensions/SerializationExtensions.cs
+++ b/Carbon.Redis/Extensions/SerializationExtensions.cs
@@ -10,24 +10,24 @@ namespace Carbon.Caching.Abstractions.Extensions
 {
     public static class SerializationExtensions
     {
-        public static byte[] ToByteArray(this object obj, Serialization serializationType = Serialization.BinaryFormatter)
+        public static byte[] ToByteArray(this object obj, CarbonContentSerializationType serializationType = CarbonContentSerializationType.BinaryFormatter)
         {
-            if (serializationType == Serialization.BinaryFormatter)
+            if (serializationType == CarbonContentSerializationType.BinaryFormatter)
                 return BinaryFormatterSerializer(obj);
-            else if (serializationType == Serialization.Json)
+            else if (serializationType == CarbonContentSerializationType.Json)
                 return JsonBinarySerializer(obj);
-            else if (serializationType == Serialization.Protobuf)
+            else if (serializationType == CarbonContentSerializationType.Protobuf)
                 return ProtobufSerializer(obj);
             else
                 throw new NotImplementedException();
         }
-        public static T FromByteArray<T>(this byte[] byteArray, Serialization serializationType = Serialization.BinaryFormatter) where T : class
+        public static T FromByteArray<T>(this byte[] byteArray, CarbonContentSerializationType serializationType = CarbonContentSerializationType.BinaryFormatter) where T : class
         {
-            if (serializationType == Serialization.BinaryFormatter)
+            if (serializationType == CarbonContentSerializationType.BinaryFormatter)
                 return BinaryFormatterDeserializer<T>(byteArray);
-            else if (serializationType == Serialization.Json)
+            else if (serializationType == CarbonContentSerializationType.Json)
                 return JsonBinaryDeserializer<T>(byteArray);
-            else if (serializationType == Serialization.Protobuf)
+            else if (serializationType == CarbonContentSerializationType.Protobuf)
                 return ProtobufDeserializer<T>(byteArray);
             else
                 throw new NotImplementedException();

--- a/Carbon.Redis/Extensions/SerializationExtensions.cs
+++ b/Carbon.Redis/Extensions/SerializationExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Text;
 using System.Text.Json;
@@ -51,7 +52,16 @@ namespace Carbon.Caching.Abstractions.Extensions
                 return default(T);
             }
             var objAsJsonString = System.Text.Encoding.UTF8.GetString(byteArray);
-            return JsonSerializer.Deserialize<T>(objAsJsonString);
+
+            try
+            {
+                var objectReturn = JsonSerializer.Deserialize<T>(objAsJsonString);
+                return objectReturn;
+            }
+            catch(JsonException)
+            {
+                return default(T);
+            }
         }
 
         private static byte[] JsonBinarySerializer(object obj)
@@ -88,7 +98,14 @@ namespace Carbon.Caching.Abstractions.Extensions
             var binaryFormatter = new BinaryFormatter();
             using (var memoryStream = new MemoryStream(byteArray))
             {
-                return binaryFormatter.Deserialize(memoryStream) as T;
+                try
+                {
+                    return binaryFormatter.Deserialize(memoryStream) as T;
+                }
+                catch(SerializationException)
+                {
+                    return default(T);
+                }
             }
         }
     }

--- a/Carbon.Redis/RedisExtensions.cs
+++ b/Carbon.Redis/RedisExtensions.cs
@@ -4,8 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
-
+using System.Text.Json;
 namespace Carbon.Redis
 {
     public static class RedisExtension
@@ -495,7 +494,7 @@ namespace Carbon.Redis
             {
                 cacheObject?.Logger?.LogError(
                     $"{{{SerilogConstant.CacheKey}}} {{{SerilogConstant.TenantId}}} {{{SerilogConstant.RequestBody}}} {{{SerilogConstant.Error}}}",
-                    cacheObject?.CacheKey, cacheObject.TenantId, JsonConvert.SerializeObject(cacheObject),
+                    cacheObject?.CacheKey, cacheObject.TenantId, JsonSerializer.Serialize(cacheObject),
                     ErrorMessageConstants.CacheRequestIsNotValid);
                 return (false, ErrorMessageConstants.CacheRequestIsNotValid);
             }
@@ -507,7 +506,7 @@ namespace Carbon.Redis
             {
                 cacheObject.Logger?.LogError(
                     $"{{{SerilogConstant.CacheKey}}} {{{SerilogConstant.TenantId}}} {{{SerilogConstant.RequestBody}}} {{{SerilogConstant.Error}}}",
-                    cacheObject.CacheKey, cacheObject.TenantId, JsonConvert.SerializeObject(cacheObject), setError);
+                    cacheObject.CacheKey, cacheObject.TenantId, JsonSerializer.Serialize(cacheObject), setError);
                 return (false, setError);
             }
 
@@ -543,7 +542,7 @@ namespace Carbon.Redis
 
             if (couldNotBeRemoved != null && couldNotBeRemoved.Any())
             {
-                var serializedObject = JsonConvert.SerializeObject(couldNotBeRemoved);
+                var serializedObject = JsonSerializer.Serialize(couldNotBeRemoved);
                 cacheObject.Logger.LogError(
                     $"{{{SerilogConstant.CacheKey}}} {{{SerilogConstant.TenantId}}}  {{{SerilogConstant.Error}}}",
                     cacheObject.CacheKey, cacheObject.TenantId,

--- a/Carbon.Redis/RedisHelper.cs
+++ b/Carbon.Redis/RedisHelper.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json;
 using StackExchange.Redis;
 using System;
 using System.Collections.Generic;
@@ -26,7 +26,7 @@ namespace Carbon.Redis
                 return string.Empty;
             }
 
-            return JsonConvert.SerializeObject(obj);
+            return JsonSerializer.Serialize(obj);
         }
         /// <summary>
         /// Gets data from Redis and converts it into the proper object
@@ -40,7 +40,7 @@ namespace Carbon.Redis
             {
                 var value = await database.StringGetAsync(key);
                 if (!value.IsNull)
-                    return JsonConvert.DeserializeObject<T>(value);
+                    return JsonSerializer.Deserialize<T>(value);
                 else
                 {
                     return default;
@@ -70,7 +70,7 @@ namespace Carbon.Redis
 
                 if (values != null)
                 {
-                    resultList.AddRange(values?.Select(value => JsonConvert.DeserializeObject<T>(value)));
+                    resultList.AddRange(values?.Select(value => JsonSerializer.Deserialize<T>(value)));
                 }
 
                 return resultList;

--- a/Carbon.Redis/ServiceCollectionExtensions.cs
+++ b/Carbon.Redis/ServiceCollectionExtensions.cs
@@ -22,6 +22,9 @@ namespace Carbon.Redis
                 await redisDatabase.StringSetAsync(RedisConstants.RedisKeyLengthKey, RedisHelper.RedisKeyLength);
             }
         }
+
+        
+
         /// <summary>
         /// Use AddRedisPersister for implementation Redis
         /// </summary>


### PR DESCRIPTION
* Carbon.Redis JSON binary serializer added on the top of binary formatter serializer which is unsupported as of dotnet 5. Simply use static method ICarbonCacheExtensions.SetSerializationType as desired serialization type which defaults to binaryformatter.

* If you try to get binaryformatter serialized keys via json binary serializer from redis, you will receive default value (such as null). At that moment, remove the existing key, and add the new one with the new serializer, or use set to replace it.

* System.Text.Json (faster) is used as master serializer/deserializer replacing Newtonsoft.Json. This may require to add [Serializable] tag over your objects, make sure you consider it!