### PR TITLE
Numerous type of handy extension methods are added

### DIFF
--- a/Carbon.Redis/Carbon.Redis.csproj
+++ b/Carbon.Redis/Carbon.Redis.csproj
@@ -2,8 +2,13 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <Version>2.1.3-preview</Version>
-    <Description>2.1.3- preview
+    <Version>2.3.0-preview</Version>
+    <Description>2.3.0-preview
+Numerous type of handy extension methods are added such as Hash, HashAsObject, Set
+Use HashAsObject to store a complete object into hash fields for boosted performance (Only supports Json serialization), and able to get selected fields rather than the entire object
+Use Set for relationships or etc.
+
+2.1.3-preview
 Carbon.Redis JSON binary serializer added on the top of binary formatter serializer which is unsupported as of dotnet 5. Simply use static method ICarbonCacheExtensions.SetSerializationType as desired serialization type which defaults to binaryformatter.
 
 If you try to get binaryformatter serialized keys via json binary serializer from redis, you will receive default value (such as null). At that moment, remove the existing key, and add the new one with the new serializer, or use set to replace it.
@@ -18,14 +23,13 @@ System.Text.Json (faster) is used as master serializer/deserializer replacing Ne
   Added SSL/TLS connection support
 1.2.0
 	Added health check.
-1.1.0
 1.0.9
 - Redis Key Length Retrieval from Configuration, not from Redis as a Key
 1.0.4
 - Scan Keys And Remove By Pattern</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <AssemblyVersion>2.1.3</AssemblyVersion>
+    <AssemblyVersion>2.3.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
*Numerous type of handy extension methods are added such as Hash, HashAsObject, Set

*Use HashAsObject to store a complete object into hash fields for boosted performance (Only supports Json serialization), and able to get selected fields rather than the entire object

*Use Set for relationships or etc.