### PR TITLE
Multiple Sentinel and Redis Cluster support

### DIFF
--- a/Carbon.Redis/Carbon.Redis.csproj
+++ b/Carbon.Redis/Carbon.Redis.csproj
@@ -2,8 +2,14 @@
 
   <PropertyGroup>
 	 <TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
-	 <Version>2.4.0-preview</Version>
-     <Description>2.4.0-preview
+	 <LangVersion>latest</LangVersion>
+	 <Version>2.5.0-preview</Version>
+     <Description>2.5.0-preview
+Multiple Sentinel and Redis Cluster support
+More accurate healthcheck for any kind of server installation (Cluster, Sentinel, Basic)
+StackExchange.Redis upgrade
+
+2.4.0-preview
 More extension methods added (Get a key from redis, if null set it via method and return)
 
 2.3.0-preview
@@ -32,18 +38,20 @@ System.Text.Json (faster) is used as master serializer/deserializer replacing Ne
 - Scan Keys And Remove By Pattern</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <AssemblyVersion>2.4.0</AssemblyVersion>
+    <AssemblyVersion>2.5.0.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AspNetCore.HealthChecks.Redis" Version="5.0.2" />
     <PackageReference Include="FastMember" Version="1.5.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="6.0.10" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="6.0.11" />
     <PackageReference Include="RedLock.net" Version="2.3.2" />
+    <PackageReference Include="StackExchange.Redis" Version="2.6.70" />
     <PackageReference Include="System.Text.Json" Version="6.0.6" />
   </ItemGroup>
 

--- a/Carbon.Redis/CustomRedisHealthCheck.cs
+++ b/Carbon.Redis/CustomRedisHealthCheck.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Carbon.Redis.Sentinel;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using StackExchange.Redis;
+using StackExchange.Redis.Configuration;
+using StackExchange.Redis.Maintenance;
+using StackExchange.Redis.Profiling;
+
+namespace Carbon.Redis
+{
+    public class CustomRedisHealthCheck : IHealthCheck
+    {
+        private readonly ConfigurationOptions _configurationOptions;
+        private readonly IConnectionMultiplexer _connection;
+        private readonly ISentinelConnectionMultiplexer _sentinelConnectionMultiplexer;
+        private static readonly object _locker = new object();
+        public CustomRedisHealthCheck(IConnectionMultiplexer connection, ConfigurationOptions configurationOptions, ISentinelConnectionMultiplexer sentinelConnectionMultiplexer)
+        {
+            _configurationOptions = configurationOptions;
+            _connection = connection;
+            _sentinelConnectionMultiplexer = sentinelConnectionMultiplexer;
+
+        }
+        /// <summary>
+        /// Non-sentinel logic is based on https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/blob/master/src/HealthChecks.Redis/RedisHealthCheck.cs
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                bool isSentinel = _sentinelConnectionMultiplexer.IsSentinel;
+                if (!isSentinel)
+                {
+                    List<IServer> serverList = new List<IServer>();
+                    foreach (var endPoint in _connection.GetEndPoints(configuredOnly: true))
+                    {
+                        var server = _connection.GetServer(endPoint);
+                        serverList.Add(server);
+                        if (server.ServerType == ServerType.Cluster)
+                        {
+                            var clusterInfo = await server.ExecuteAsync("CLUSTER", "INFO");
+
+                            if (clusterInfo is object && !clusterInfo.IsNull)
+                            {
+                                if (!clusterInfo.ToString()!.Contains("cluster_state:ok"))
+                                {
+                                    //cluster info is not ok!
+                                    return new HealthCheckResult(context.Registration.FailureStatus, description: $"INFO CLUSTER is not on OK state for endpoint {endPoint}");
+                                }
+                            }
+                            else
+                            {
+                                //cluster info cannot be read for this cluster node
+                                return new HealthCheckResult(context.Registration.FailureStatus, description: $"INFO CLUSTER is null or can't be read for endpoint {endPoint}");
+                            }
+                        }
+                        else
+                        {
+                            await _connection.GetDatabase().PingAsync();
+                            await server.PingAsync();
+                        }
+                    }
+                    return HealthCheckResult.Healthy($"Healthy Redis with given servers: {String.Join(",", serverList.Select(k => k.EndPoint.ToString()).ToList())}");
+                }
+                else
+                {
+                    var allSentinelServers = _sentinelConnectionMultiplexer.ConnectionMultiplexer.GetServers();
+                    string serviceName = _configurationOptions.ServiceName;
+                    EndPoint foundRunningMasterUrl = default;
+
+                    List<Task> sentinelCheckTasks = new List<Task>();
+                    foreach (var server in allSentinelServers)
+                    {
+                        sentinelCheckTasks.Add(Task.Run(() =>
+                        {
+                            try
+                            {
+                                var masterAddressFoundByThisServer = server.SentinelGetMasterAddressByName(serviceName);
+                                lock (_locker)
+                                {
+                                    foundRunningMasterUrl = masterAddressFoundByThisServer;
+                                }
+                            }
+                            catch
+                            {
+
+                            }
+                        }));
+                    }
+
+                    await Task.WhenAll(sentinelCheckTasks);
+
+
+                    if (foundRunningMasterUrl == default)
+                    {
+                        return new HealthCheckResult(context.Registration.FailureStatus, description: $"Unhealthy Redis Sentinel: No healthy master found in the given server set: {String.Join(",", allSentinelServers.Select(k => k.EndPoint.ToString()).ToList())}");
+                    }
+                    return HealthCheckResult.Healthy($"Healthy Redis Sentinel with given sentinel servers: {String.Join(",", allSentinelServers.Select(k => k.EndPoint.ToString()).ToList())} and selected master is {foundRunningMasterUrl}");
+                }
+
+            }
+            catch (Exception ex)
+            {
+                return new HealthCheckResult(context.Registration.FailureStatus, exception: ex);
+            }
+        }
+    }
+}

--- a/Carbon.Redis/DummyConnectionMultiplexer.cs
+++ b/Carbon.Redis/DummyConnectionMultiplexer.cs
@@ -62,6 +62,11 @@ namespace Carbon.Redis
 
         }
 
+        public ValueTask DisposeAsync()
+        {
+            throw new NotImplementedException();
+        }
+
         public void ExportConfiguration(Stream destination, ExportOptions options = (ExportOptions)(-1))
         {
 
@@ -105,6 +110,11 @@ namespace Carbon.Redis
         public IServer GetServer(EndPoint endpoint, object asyncState = null)
         {
             return new DummyRedisServer();
+        }
+
+        public IServer[] GetServers()
+        {
+            throw new NotImplementedException();
         }
 
         public string GetStatus()

--- a/Carbon.Redis/DummyRedisServer.cs
+++ b/Carbon.Redis/DummyRedisServer.cs
@@ -599,5 +599,40 @@ namespace Carbon.Redis
         {
             throw new NotImplementedException();
         }
+
+        public long CommandCount(CommandFlags flags = CommandFlags.None)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<long> CommandCountAsync(CommandFlags flags = CommandFlags.None)
+        {
+            throw new NotImplementedException();
+        }
+
+        public RedisKey[] CommandGetKeys(RedisValue[] command, CommandFlags flags = CommandFlags.None)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<RedisKey[]> CommandGetKeysAsync(RedisValue[] command, CommandFlags flags = CommandFlags.None)
+        {
+            throw new NotImplementedException();
+        }
+
+        public string[] CommandList(RedisValue? moduleName = null, RedisValue? category = null, RedisValue? pattern = null, CommandFlags flags = CommandFlags.None)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<string[]> CommandListAsync(RedisValue? moduleName = null, RedisValue? category = null, RedisValue? pattern = null, CommandFlags flags = CommandFlags.None)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task MakePrimaryAsync(ReplicationChangeOptions options, TextWriter log = null)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/Carbon.Redis/IRedisSettings.cs
+++ b/Carbon.Redis/IRedisSettings.cs
@@ -77,6 +77,8 @@ namespace Carbon.Redis
         /// Sentinel Enablement
         /// </summary>
         public string SentinelServiceName { get; set; }
+        public int SyncTimeout { get; set; }
+
 
     }
 }

--- a/Carbon.Redis/RedisDatabase.cs
+++ b/Carbon.Redis/RedisDatabase.cs
@@ -173,6 +173,46 @@ namespace Carbon.Redis
             return default;
         }
 
+        public GeoRadiusResult[] GeoSearch(RedisKey key, RedisValue member, GeoSearchShape shape, int count = -1, bool demandClosest = true, Order? order = null, GeoRadiusOptions options = GeoRadiusOptions.Default, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public GeoRadiusResult[] GeoSearch(RedisKey key, double longitude, double latitude, GeoSearchShape shape, int count = -1, bool demandClosest = true, Order? order = null, GeoRadiusOptions options = GeoRadiusOptions.Default, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public long GeoSearchAndStore(RedisKey sourceKey, RedisKey destinationKey, RedisValue member, GeoSearchShape shape, int count = -1, bool demandClosest = true, Order? order = null, bool storeDistances = false, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public long GeoSearchAndStore(RedisKey sourceKey, RedisKey destinationKey, double longitude, double latitude, GeoSearchShape shape, int count = -1, bool demandClosest = true, Order? order = null, bool storeDistances = false, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public Task<long> GeoSearchAndStoreAsync(RedisKey sourceKey, RedisKey destinationKey, RedisValue member, GeoSearchShape shape, int count = -1, bool demandClosest = true, Order? order = null, bool storeDistances = false, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public Task<long> GeoSearchAndStoreAsync(RedisKey sourceKey, RedisKey destinationKey, double longitude, double latitude, GeoSearchShape shape, int count = -1, bool demandClosest = true, Order? order = null, bool storeDistances = false, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public Task<GeoRadiusResult[]> GeoSearchAsync(RedisKey key, RedisValue member, GeoSearchShape shape, int count = -1, bool demandClosest = true, Order? order = null, GeoRadiusOptions options = GeoRadiusOptions.Default, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public Task<GeoRadiusResult[]> GeoSearchAsync(RedisKey key, double longitude, double latitude, GeoSearchShape shape, int count = -1, bool demandClosest = true, Order? order = null, GeoRadiusOptions options = GeoRadiusOptions.Default, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
         public long HashDecrement(RedisKey key, RedisValue hashField, long value = 1, CommandFlags flags = CommandFlags.None)
         {
             return default;
@@ -299,6 +339,36 @@ namespace Carbon.Redis
         }
 
         public Task<long> HashLengthAsync(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public RedisValue HashRandomField(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public Task<RedisValue> HashRandomFieldAsync(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public RedisValue[] HashRandomFields(RedisKey key, long count, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public Task<RedisValue[]> HashRandomFieldsAsync(RedisKey key, long count, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public HashEntry[] HashRandomFieldsWithValues(RedisKey key, long count, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public Task<HashEntry[]> HashRandomFieldsWithValuesAsync(RedisKey key, long count, CommandFlags flags = CommandFlags.None)
         {
             return default;
         }
@@ -433,6 +503,16 @@ namespace Carbon.Redis
             return default;
         }
 
+        public bool KeyCopy(RedisKey sourceKey, RedisKey destinationKey, int destinationDatabase = -1, bool replace = false, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public Task<bool> KeyCopyAsync(RedisKey sourceKey, RedisKey destinationKey, int destinationDatabase = -1, bool replace = false, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
         public bool KeyDelete(RedisKey key, CommandFlags flags = CommandFlags.None)
         {
             return true;
@@ -459,6 +539,16 @@ namespace Carbon.Redis
         }
 
         public Task<byte[]> KeyDumpAsync(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public string KeyEncoding(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public Task<string> KeyEncodingAsync(RedisKey key, CommandFlags flags = CommandFlags.None)
         {
             return default;
         }
@@ -493,12 +583,52 @@ namespace Carbon.Redis
             return default;
         }
 
+        public bool KeyExpire(RedisKey key, TimeSpan? expiry, ExpireWhen when = ExpireWhen.Always, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public bool KeyExpire(RedisKey key, DateTime? expiry, ExpireWhen when = ExpireWhen.Always, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
         public Task<bool> KeyExpireAsync(RedisKey key, TimeSpan? expiry, CommandFlags flags = CommandFlags.None)
         {
             return default;
         }
 
         public Task<bool> KeyExpireAsync(RedisKey key, DateTime? expiry, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public Task<bool> KeyExpireAsync(RedisKey key, TimeSpan? expiry, ExpireWhen when = ExpireWhen.Always, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public Task<bool> KeyExpireAsync(RedisKey key, DateTime? expiry, ExpireWhen when = ExpireWhen.Always, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public DateTime? KeyExpireTime(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public Task<DateTime?> KeyExpireTimeAsync(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public long? KeyFrequency(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public Task<long?> KeyFrequencyAsync(RedisKey key, CommandFlags flags = CommandFlags.None)
         {
             return default;
         }
@@ -549,6 +679,16 @@ namespace Carbon.Redis
         }
 
         public Task<RedisKey> KeyRandomAsync(CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public long? KeyRefCount(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public Task<long?> KeyRefCountAsync(RedisKey key, CommandFlags flags = CommandFlags.None)
         {
             return default;
         }
@@ -648,7 +788,27 @@ namespace Carbon.Redis
             return default;
         }
 
+        public RedisValue[] ListLeftPop(RedisKey key, long count, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public ListPopResult ListLeftPop(RedisKey[] keys, long count, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
         public Task<RedisValue> ListLeftPopAsync(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public Task<RedisValue[]> ListLeftPopAsync(RedisKey key, long count, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public Task<ListPopResult> ListLeftPopAsync(RedisKey[] keys, long count, CommandFlags flags = CommandFlags.None)
         {
             return default;
         }
@@ -665,7 +825,7 @@ namespace Carbon.Redis
 
         public long ListLeftPush(RedisKey key, RedisValue[] values, When when = When.Always, CommandFlags flags = CommandFlags.None)
         {
-            throw new NotImplementedException();
+            return default;
         }
 
         public Task<long> ListLeftPushAsync(RedisKey key, RedisValue value, When when = When.Always, CommandFlags flags = CommandFlags.None)
@@ -680,7 +840,7 @@ namespace Carbon.Redis
 
         public Task<long> ListLeftPushAsync(RedisKey key, RedisValue[] values, When when = When.Always, CommandFlags flags = CommandFlags.None)
         {
-            throw new NotImplementedException();
+            return default;
         }
 
         public long ListLength(RedisKey key, CommandFlags flags = CommandFlags.None)
@@ -689,6 +849,36 @@ namespace Carbon.Redis
         }
 
         public Task<long> ListLengthAsync(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public RedisValue ListMove(RedisKey sourceKey, RedisKey destinationKey, ListSide sourceSide, ListSide destinationSide, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public Task<RedisValue> ListMoveAsync(RedisKey sourceKey, RedisKey destinationKey, ListSide sourceSide, ListSide destinationSide, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public long ListPosition(RedisKey key, RedisValue element, long rank = 1, long maxLength = 0, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public Task<long> ListPositionAsync(RedisKey key, RedisValue element, long rank = 1, long maxLength = 0, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public long[] ListPositions(RedisKey key, RedisValue element, long count, long rank = 1, long maxLength = 0, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public Task<long[]> ListPositionsAsync(RedisKey key, RedisValue element, long count, long rank = 1, long maxLength = 0, CommandFlags flags = CommandFlags.None)
         {
             return default;
         }
@@ -718,7 +908,27 @@ namespace Carbon.Redis
             return default;
         }
 
+        public RedisValue[] ListRightPop(RedisKey key, long count, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public ListPopResult ListRightPop(RedisKey[] keys, long count, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
         public Task<RedisValue> ListRightPopAsync(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public Task<RedisValue[]> ListRightPopAsync(RedisKey key, long count, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public Task<ListPopResult> ListRightPopAsync(RedisKey[] keys, long count, CommandFlags flags = CommandFlags.None)
         {
             return default;
         }
@@ -745,7 +955,7 @@ namespace Carbon.Redis
 
         public long ListRightPush(RedisKey key, RedisValue[] values, When when = When.Always, CommandFlags flags = CommandFlags.None)
         {
-            throw new NotImplementedException();
+            return default;
         }
 
         public Task<long> ListRightPushAsync(RedisKey key, RedisValue value, When when = When.Always, CommandFlags flags = CommandFlags.None)
@@ -760,7 +970,7 @@ namespace Carbon.Redis
 
         public Task<long> ListRightPushAsync(RedisKey key, RedisValue[] values, When when = When.Always, CommandFlags flags = CommandFlags.None)
         {
-            throw new NotImplementedException();
+            return default;
         }
 
         public void ListSetByIndex(RedisKey key, long index, RedisValue value, CommandFlags flags = CommandFlags.None)
@@ -948,7 +1158,27 @@ namespace Carbon.Redis
             return default;
         }
 
+        public bool[] SetContains(RedisKey key, RedisValue[] values, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
         public Task<bool> SetContainsAsync(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public Task<bool[]> SetContainsAsync(RedisKey key, RedisValue[] values, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public long SetIntersectionLength(RedisKey[] keys, long limit = 0, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public Task<long> SetIntersectionLengthAsync(RedisKey[] keys, long limit = 0, CommandFlags flags = CommandFlags.None)
         {
             return default;
         }
@@ -1098,6 +1328,16 @@ namespace Carbon.Redis
             return default;
         }
 
+        public bool SortedSetAdd(RedisKey key, RedisValue member, double score, SortedSetWhen when = SortedSetWhen.Always, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public long SortedSetAdd(RedisKey key, SortedSetEntry[] values, SortedSetWhen when = SortedSetWhen.Always, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
         public Task<bool> SortedSetAddAsync(RedisKey key, RedisValue member, double score, CommandFlags flags)
         {
             return default;
@@ -1114,6 +1354,21 @@ namespace Carbon.Redis
         }
 
         public Task<long> SortedSetAddAsync(RedisKey key, SortedSetEntry[] values, When when = When.Always, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public Task<bool> SortedSetAddAsync(RedisKey key, RedisValue member, double score, SortedSetWhen when = SortedSetWhen.Always, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public Task<long> SortedSetAddAsync(RedisKey key, SortedSetEntry[] values, SortedSetWhen when = SortedSetWhen.Always, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public RedisValue[] SortedSetCombine(SetOperation operation, RedisKey[] keys, double[] weights = null, Aggregate aggregate = Aggregate.Sum, CommandFlags flags = CommandFlags.None)
         {
             return default;
         }
@@ -1138,6 +1393,21 @@ namespace Carbon.Redis
             return default;
         }
 
+        public Task<RedisValue[]> SortedSetCombineAsync(SetOperation operation, RedisKey[] keys, double[] weights = null, Aggregate aggregate = Aggregate.Sum, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public SortedSetEntry[] SortedSetCombineWithScores(SetOperation operation, RedisKey[] keys, double[] weights = null, Aggregate aggregate = Aggregate.Sum, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public Task<SortedSetEntry[]> SortedSetCombineWithScoresAsync(SetOperation operation, RedisKey[] keys, double[] weights = null, Aggregate aggregate = Aggregate.Sum, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
         public double SortedSetDecrement(RedisKey key, RedisValue member, double value, CommandFlags flags = CommandFlags.None)
         {
             return default;
@@ -1154,6 +1424,16 @@ namespace Carbon.Redis
         }
 
         public Task<double> SortedSetIncrementAsync(RedisKey key, RedisValue member, double value, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public long SortedSetIntersectionLength(RedisKey[] keys, long limit = 0, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public Task<long> SortedSetIntersectionLengthAsync(RedisKey[] keys, long limit = 0, CommandFlags flags = CommandFlags.None)
         {
             return default;
         }
@@ -1188,12 +1468,62 @@ namespace Carbon.Redis
             return default;
         }
 
+        public SortedSetPopResult SortedSetPop(RedisKey[] keys, long count, Order order = Order.Ascending, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
         public Task<SortedSetEntry?> SortedSetPopAsync(RedisKey key, Order order = Order.Ascending, CommandFlags flags = CommandFlags.None)
         {
             return default;
         }
 
         public Task<SortedSetEntry[]> SortedSetPopAsync(RedisKey key, long count, Order order = Order.Ascending, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public Task<SortedSetPopResult> SortedSetPopAsync(RedisKey[] keys, long count, Order order = Order.Ascending, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public RedisValue SortedSetRandomMember(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public Task<RedisValue> SortedSetRandomMemberAsync(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public RedisValue[] SortedSetRandomMembers(RedisKey key, long count, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public Task<RedisValue[]> SortedSetRandomMembersAsync(RedisKey key, long count, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public SortedSetEntry[] SortedSetRandomMembersWithScores(RedisKey key, long count, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public Task<SortedSetEntry[]> SortedSetRandomMembersWithScoresAsync(RedisKey key, long count, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public long SortedSetRangeAndStore(RedisKey sourceKey, RedisKey destinationKey, RedisValue start, RedisValue stop, SortedSetOrder sortedSetOrder = SortedSetOrder.ByRank, Exclude exclude = Exclude.None, Order order = Order.Ascending, long skip = 0, long? take = null, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public Task<long> SortedSetRangeAndStoreAsync(RedisKey sourceKey, RedisKey destinationKey, RedisValue start, RedisValue stop, SortedSetOrder sortedSetOrder = SortedSetOrder.ByRank, Exclude exclude = Exclude.None, Order order = Order.Ascending, long skip = 0, long? take = null, CommandFlags flags = CommandFlags.None)
         {
             return default;
         }
@@ -1343,6 +1673,36 @@ namespace Carbon.Redis
             return default;
         }
 
+        public double?[] SortedSetScores(RedisKey key, RedisValue[] members, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public Task<double?[]> SortedSetScoresAsync(RedisKey key, RedisValue[] members, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public bool SortedSetUpdate(RedisKey key, RedisValue member, double score, SortedSetWhen when = SortedSetWhen.Always, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public long SortedSetUpdate(RedisKey key, SortedSetEntry[] values, SortedSetWhen when = SortedSetWhen.Always, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public Task<bool> SortedSetUpdateAsync(RedisKey key, RedisValue member, double score, SortedSetWhen when = SortedSetWhen.Always, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public Task<long> SortedSetUpdateAsync(RedisKey key, SortedSetEntry[] values, SortedSetWhen when = SortedSetWhen.Always, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
         public long StreamAcknowledge(RedisKey key, RedisValue groupName, RedisValue messageId, CommandFlags flags = CommandFlags.None)
         {
             return default;
@@ -1379,6 +1739,26 @@ namespace Carbon.Redis
         }
 
         public Task<RedisValue> StreamAddAsync(RedisKey key, NameValueEntry[] streamPairs, RedisValue? messageId = null, int? maxLength = null, bool useApproximateMaxLength = false, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public StreamAutoClaimResult StreamAutoClaim(RedisKey key, RedisValue consumerGroup, RedisValue claimingConsumer, long minIdleTimeInMs, RedisValue startAtId, int? count = null, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public Task<StreamAutoClaimResult> StreamAutoClaimAsync(RedisKey key, RedisValue consumerGroup, RedisValue claimingConsumer, long minIdleTimeInMs, RedisValue startAtId, int? count = null, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public StreamAutoClaimIdsOnlyResult StreamAutoClaimIdsOnly(RedisKey key, RedisValue consumerGroup, RedisValue claimingConsumer, long minIdleTimeInMs, RedisValue startAtId, int? count = null, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public Task<StreamAutoClaimIdsOnlyResult> StreamAutoClaimIdsOnlyAsync(RedisKey key, RedisValue consumerGroup, RedisValue claimingConsumer, long minIdleTimeInMs, RedisValue startAtId, int? count = null, CommandFlags flags = CommandFlags.None)
         {
             return default;
         }
@@ -1618,7 +1998,17 @@ namespace Carbon.Redis
             return default;
         }
 
+        public long StringBitCount(RedisKey key, long start = 0, long end = -1, StringIndexType indexType = StringIndexType.Byte, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
         public Task<long> StringBitCountAsync(RedisKey key, long start = 0, long end = -1, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public Task<long> StringBitCountAsync(RedisKey key, long start = 0, long end = -1, StringIndexType indexType = StringIndexType.Byte, CommandFlags flags = CommandFlags.None)
         {
             return default;
         }
@@ -1648,7 +2038,17 @@ namespace Carbon.Redis
             return default;
         }
 
+        public long StringBitPosition(RedisKey key, bool bit, long start = 0, long end = -1, StringIndexType indexType = StringIndexType.Byte, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
         public Task<long> StringBitPositionAsync(RedisKey key, bool bit, long start = 0, long end = -1, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public Task<long> StringBitPositionAsync(RedisKey key, bool bit, long start = 0, long end = -1, StringIndexType indexType = StringIndexType.Byte, CommandFlags flags = CommandFlags.None)
         {
             return default;
         }
@@ -1703,6 +2103,16 @@ namespace Carbon.Redis
             return default;
         }
 
+        public RedisValue StringGetDelete(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public Task<RedisValue> StringGetDeleteAsync(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
         public Lease<byte> StringGetLease(RedisKey key, CommandFlags flags = CommandFlags.None)
         {
             return default;
@@ -1729,6 +2139,26 @@ namespace Carbon.Redis
         }
 
         public Task<RedisValue> StringGetSetAsync(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public RedisValue StringGetSetExpiry(RedisKey key, TimeSpan? expiry, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public RedisValue StringGetSetExpiry(RedisKey key, DateTime expiry, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public Task<RedisValue> StringGetSetExpiryAsync(RedisKey key, TimeSpan? expiry, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public Task<RedisValue> StringGetSetExpiryAsync(RedisKey key, DateTime expiry, CommandFlags flags = CommandFlags.None)
         {
             return default;
         }
@@ -1773,6 +2203,36 @@ namespace Carbon.Redis
             return default;
         }
 
+        public string StringLongestCommonSubsequence(RedisKey first, RedisKey second, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public Task<string> StringLongestCommonSubsequenceAsync(RedisKey first, RedisKey second, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public long StringLongestCommonSubsequenceLength(RedisKey first, RedisKey second, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public Task<long> StringLongestCommonSubsequenceLengthAsync(RedisKey first, RedisKey second, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public LCSMatchResult StringLongestCommonSubsequenceWithMatches(RedisKey first, RedisKey second, long minLength = 0, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public Task<LCSMatchResult> StringLongestCommonSubsequenceWithMatchesAsync(RedisKey first, RedisKey second, long minLength = 0, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
         public bool StringSet(RedisKey key, RedisValue value, TimeSpan? expiry = null, When when = When.Always, CommandFlags flags = CommandFlags.None)
         {
             return default;
@@ -1783,12 +2243,52 @@ namespace Carbon.Redis
             return default;
         }
 
+        public bool StringSet(RedisKey key, RedisValue value, TimeSpan? expiry, When when)
+        {
+            return default;
+        }
+
+        public bool StringSet(RedisKey key, RedisValue value, TimeSpan? expiry = null, bool keepTtl = false, When when = When.Always, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public RedisValue StringSetAndGet(RedisKey key, RedisValue value, TimeSpan? expiry, When when, CommandFlags flags)
+        {
+            return default;
+        }
+
+        public RedisValue StringSetAndGet(RedisKey key, RedisValue value, TimeSpan? expiry = null, bool keepTtl = false, When when = When.Always, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public Task<RedisValue> StringSetAndGetAsync(RedisKey key, RedisValue value, TimeSpan? expiry, When when, CommandFlags flags)
+        {
+            return default;
+        }
+
+        public Task<RedisValue> StringSetAndGetAsync(RedisKey key, RedisValue value, TimeSpan? expiry = null, bool keepTtl = false, When when = When.Always, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
         public async Task<bool> StringSetAsync(RedisKey key, RedisValue value, TimeSpan? expiry = null, When when = When.Always, CommandFlags flags = CommandFlags.None)
         {
             return default;
         }
 
         public async Task<bool> StringSetAsync(KeyValuePair<RedisKey, RedisValue>[] values, When when = When.Always, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public Task<bool> StringSetAsync(RedisKey key, RedisValue value, TimeSpan? expiry, When when)
+        {
+            return default;
+        }
+
+        public Task<bool> StringSetAsync(RedisKey key, RedisValue value, TimeSpan? expiry = null, bool keepTtl = false, When when = When.Always, CommandFlags flags = CommandFlags.None)
         {
             return default;
         }

--- a/Carbon.Redis/RedisSettings.cs
+++ b/Carbon.Redis/RedisSettings.cs
@@ -28,6 +28,7 @@ namespace Carbon.Redis
         public bool SSLEnabled { get; set; }
         public string InstanceName { get; set; }
         public string SentinelServiceName { get; set; }
+        public int SyncTimeout { get; set; }
         public RedisSettings Value => this;
     }
 }

--- a/Carbon.Redis/Sentinel/ISentinelConnectionMultiplexer.cs
+++ b/Carbon.Redis/Sentinel/ISentinelConnectionMultiplexer.cs
@@ -1,0 +1,15 @@
+﻿using StackExchange.Redis;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Carbon.Redis.Sentinel
+{
+    public interface ISentinelConnectionMultiplexer
+    {
+        ConnectionMultiplexer ConnectionMultiplexer { get; }
+        Boolean IsSentinel { get; }
+    }
+}

--- a/Carbon.Redis/Sentinel/SentinelConnectionMultiplexer.cs
+++ b/Carbon.Redis/Sentinel/SentinelConnectionMultiplexer.cs
@@ -1,0 +1,33 @@
+﻿using StackExchange.Redis;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Carbon.Redis.Sentinel
+{
+    public class SentinelConnectionMultiplexer : ISentinelConnectionMultiplexer
+    {
+        public SentinelConnectionMultiplexer(ConnectionMultiplexer connectionMultiplexer)
+        {
+            ConnectionMultiplexer = connectionMultiplexer;
+            IsSentinel = true;
+        }
+
+        public ConnectionMultiplexer ConnectionMultiplexer { get; }
+        public bool IsSentinel { get; }
+    }
+
+    public class NonSentinelConnectionMultiplexer : ISentinelConnectionMultiplexer
+    {
+        public NonSentinelConnectionMultiplexer(ConnectionMultiplexer connectionMultiplexer)
+        {
+            ConnectionMultiplexer = connectionMultiplexer;
+            IsSentinel= false;
+        }
+
+        public ConnectionMultiplexer ConnectionMultiplexer { get; }
+        public bool IsSentinel { get; }
+    }
+}

--- a/Carbon.Redis/ServiceCollectionExtensions.cs
+++ b/Carbon.Redis/ServiceCollectionExtensions.cs
@@ -41,12 +41,18 @@ namespace Carbon.Redis
             {
                 throw new ArgumentNullException(nameof(configuration));
             }
+
             IOptions<RedisSettings> redisSettings = new RedisSettings();
             configuration.GetSection(RedisConstants.RedisSectionName).Bind(redisSettings);
             services.AddSingleton(redisSettings);
             ConfigurationOptions configurationOptions = new ConfigurationOptions();
             if (redisSettings.Value.Enabled)
             {
+                if(redisSettings.Value.EndPoints == null || !redisSettings.Value.EndPoints.Any())
+                {
+                    throw new ArgumentNullException(nameof(redisSettings.Value.EndPoints));
+                }
+
                 EndPointCollection endPoints = new EndPointCollection();
                 foreach (var endpoint in redisSettings.Value.EndPoints)
                 {


### PR DESCRIPTION
- Multiple nodes of Sentinel and Redis Cluster support (It was buggy previously, even if you could define multiple in config, it was causing an unexpected behaviour)
- More accurate healthcheck for any kind of server installation (Cluster, Sentinel, Basic)

- StackExchange.Redis upgrade