### PR TITLE
[Carbon.MassTransit] Quorum Queues introduced

### DIFF
--- a/Carbon.MassTransit/Carbon.MassTransit.csproj
+++ b/Carbon.MassTransit/Carbon.MassTransit.csproj
@@ -2,8 +2,10 @@
 
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
-		<Version>3.6.1</Version>
-		<Description>     3.6.0
+		<Version>3.7.0</Version>
+		<Description>     3.7.0
+    - HighAvailable Queues introduced (powered by quorum)
+    3.6.0
      - ReqRespAsync as GetResponse/Respond Pattern introduced
      - Awaitable saga, routing slip or ReqRespAsync
      - Some other useful extension methods

--- a/Carbon.MassTransit/IServiceCollectionConfiguratorExtensions.cs
+++ b/Carbon.MassTransit/IServiceCollectionConfiguratorExtensions.cs
@@ -279,6 +279,27 @@ namespace Carbon.MassTransit
             });
         }
 
+        /// <summary>
+        /// ReceiveEndpoint queue will be declared as a quorum queue, if it is already declared as default, it will delete the existing one and create new HA queue
+        /// </summary>
+        /// <param name="cfg"></param>
+        /// <param name="configuration">Configuration</param>
+        public static void AddAsHighAvailableQueue(this IRabbitMqReceiveEndpointConfigurator cfg,
+                                      IConfiguration configuration)
+        {
+            cfg.SetQuorumQueue(3);
+            cfg.ConnectReceiveEndpointObserver(new ReceiveEndpointObserver(configuration));
+        }
+        /// <summary>
+        /// ReceiveEndpoint queue will be declared as a classic queue, if it is already declared as quorum or something else, it will delete the existing one and create new classic queue
+        /// </summary>
+        /// <param name="cfg"></param>
+        /// <param name="configuration">Configuration</param>
+        public static void AddAsDefaultQueue(this IRabbitMqReceiveEndpointConfigurator cfg,
+                                      IConfiguration configuration)
+        {
+            cfg.ConnectReceiveEndpointObserver(new ReceiveEndpointObserver(configuration));
+        }
 
         /// <summary>
         /// Azure Service Bus Add Extension Method

--- a/Carbon.MassTransit/IServiceCollectionConfiguratorExtensions.cs
+++ b/Carbon.MassTransit/IServiceCollectionConfiguratorExtensions.cs
@@ -212,6 +212,7 @@ namespace Carbon.MassTransit
                 {
                     busFactoryConfig.ReceiveEndpoint("request-starter-state", e =>
                     {
+                        e.AddAsHighAvailableQueue(configuration);
                         e.ConfigureSaga<RequestResponseState>((IBusRegistrationContext)provider);
                     });
 
@@ -219,6 +220,7 @@ namespace Carbon.MassTransit
 
                     busFactoryConfig.ReceiveEndpoint(apiname + "-Req.Resp.Async-RespHandler", configurator =>
                     {
+                        configurator.AddAsHighAvailableQueue(configuration);
                         configurator.Consumer<T>(provider);
                     });
                 });
@@ -264,6 +266,7 @@ namespace Carbon.MassTransit
 
                     busFactoryConfig.ReceiveEndpoint("Req.Resp.Async-" + responseDestinationPath, configurator =>
                     {
+                        configurator.AddAsHighAvailableQueue(configuration);
                         configurator.Consumer<T>(provider);
                     });
 
@@ -295,7 +298,7 @@ namespace Carbon.MassTransit
         /// </summary>
         /// <param name="cfg"></param>
         /// <param name="configuration">Configuration</param>
-        public static void AddAsDefaultQueue(this IRabbitMqReceiveEndpointConfigurator cfg,
+        public static void AddAsDefaultQueue(this IReceiveEndpointConfigurator cfg,
                                       IConfiguration configuration)
         {
             cfg.ConnectReceiveEndpointObserver(new ReceiveEndpointObserver(configuration));

--- a/Carbon.MassTransit/ReceiveEndpointObserver.cs
+++ b/Carbon.MassTransit/ReceiveEndpointObserver.cs
@@ -1,0 +1,62 @@
+﻿using Carbon.MassTransit;
+using MassTransit;
+using Microsoft.Extensions.Configuration;
+using System;
+using System.Threading.Tasks;
+
+namespace Carbon.MassTransit
+{
+    public class ReceiveEndpointObserver : IReceiveEndpointObserver
+    {
+        private readonly IConfiguration _configuration;
+        public ReceiveEndpointObserver(IConfiguration configuration)
+        {
+            _configuration = configuration;
+        }
+        public Task Completed(ReceiveEndpointCompleted completed)
+        {
+            return Task.FromResult(true);
+        }
+
+        public Task Faulted(ReceiveEndpointFaulted faulted)
+        {
+            //queue-type based exceptions handled here
+            if (faulted.Exception.InnerException is RabbitMQ.Client.Exceptions.OperationInterruptedException)
+            {
+                var fault = ((RabbitMQ.Client.Exceptions.OperationInterruptedException)faulted.Exception.InnerException);
+                ushort faultCode = fault.ShutdownReason.ReplyCode;
+                string faultMessage = fault.ShutdownReason.ReplyText;
+                //If it is an existing queue with different type, delete it and let MassTransit create again
+                if (faultCode == 406 && faultMessage.Contains("x-queue-type"))
+                {
+                    var massTransitSettings = _configuration.GetSection("MassTransit").Get<MassTransitSettings>();
+                    var busSettings = massTransitSettings.RabbitMq;
+                    var rabbitMqUql = $"amqp://{busSettings.Username}:{busSettings.Password}@{busSettings.Host}:{busSettings.Port}{busSettings.VirtualHost}";
+
+                    var factory = new RabbitMQ.Client.ConnectionFactory()
+                    {
+                        Uri = new Uri(rabbitMqUql)
+                    };
+                    var absolutePath = faulted.ReceiveEndpoint.InputAddress.AbsolutePath.Split('/');
+                    var queueName = absolutePath[absolutePath.Length - 1];
+                    using (var connection = factory.CreateConnection())
+                    {
+                        using (var channel = connection.CreateModel())
+                            channel.QueueDelete(queueName, false, false);
+                    }
+                }
+            }
+            return Task.FromResult(true);
+        }
+
+        public Task Ready(ReceiveEndpointReady ready)
+        {
+            return Task.FromResult(true);
+        }
+
+        public Task Stopping(ReceiveEndpointStopping stopping)
+        {
+            return Task.FromResult(true);
+        }
+    }
+}


### PR DESCRIPTION
You can create quorum queues, or migrate your classic queues to quorum queues automatically.

Beware of that, during the migration data loss may occur. 