### PR TITLE
AddRabbitMqBus and AddServiceBus overloads

### DIFF
--- a/Carbon.MassTransit/Carbon.MassTransit.csproj
+++ b/Carbon.MassTransit/Carbon.MassTransit.csproj
@@ -2,51 +2,55 @@
 
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
-		<Version>3.7.5</Version>
-		<Description>   3.7.5
-   - Fixed a critical bug when ReqRespAsync is used in multiple APIs and same virtual hosts    
-   - Add multiple responder to your project
-    3.7.2
-    -Fixed a bug for quorum ReqRespAsync patterns 
-    3.7.0
-    - HighAvailable Queues introduced (powered by quorum)
-    3.6.0
-     - ReqRespAsync as GetResponse/Respond Pattern introduced
-     - Awaitable saga, routing slip or ReqRespAsync
-     - Some other useful extension methods
-     3.5.2
-     - Minor fixes
-     - Request Response Async Pattern response sender can send response from anywhere thanks to bus 
-     3.5.0
-      - Request-Response Async Pattern introduced
-      3.4.0
-      - Masstransit upgraded to latest 7.x.x version
-      - Masstransit HostedService is now using the as-is one comes directly from MassTransit package
-      - RabbitMQ Healthchecks are now more accurate including all the consumers and their healthiness
-     3.3.0
-      - RoutingSlip pattern Added (ConsumeRoutingSlipActivity as consumer)
-      3.1.1
-      - MultiBus Hosted Service registration fixed
-      3.1.0
-      - MultiBus Support Added
-      3.0.4
-      -Health Check with IConnection
-      3.0.3
-      -Buggy Rabbitmq healthcheck removed temporarily, will be fixed in a later version
-      3.0.2
-      -Added Health Check
-      3.0.1
-      -Recovered the port settings feature from 2.0.8
-      3.0.0
-      -MassTransit 7.1.5 support added
-      2.1.0
-      -MassTransit 6.3.1 support added. Use this version, if MassTransit 6.3.1 required in your project.
-      2.0.8
-      -Port Issue fixed (RabbitMQ started using the port number in settings.)
-      2.0.7
-      -Prefetch Count Added
-      -
-</Description>
+		<Version>3.8.0</Version>
+		<Description>   
+			3.8.0
+			    - It is now possible to supply custom configuration objects to AddRabbitMqBus and AddServiceBus extensions.
+				- It is now possible to give custom health check tags to AddRabbitMqBus extensions (helps in avoiding duplicates).
+			3.7.5
+                - Fixed a critical bug when ReqRespAsync is used in multiple APIs and same virtual hosts    
+                - Add multiple responder to your project
+            3.7.2
+                -Fixed a bug for quorum ReqRespAsync patterns 
+            3.7.0
+                - HighAvailable Queues introduced (powered by quorum)
+            3.6.0
+                - ReqRespAsync as GetResponse/Respond Pattern introduced
+                - Awaitable saga, routing slip or ReqRespAsync
+                - Some other useful extension methods
+            3.5.2
+                - Minor fixes
+                - Request Response Async Pattern response sender can send response from anywhere thanks to bus 
+            3.5.0
+                - Request-Response Async Pattern introduced
+            3.4.0
+                - Masstransit upgraded to latest 7.x.x version
+                - Masstransit HostedService is now using the as-is one comes directly from MassTransit package
+                - RabbitMQ Healthchecks are now more accurate including all the consumers and their healthiness
+            3.3.0
+                - RoutingSlip pattern Added (ConsumeRoutingSlipActivity as consumer)
+            3.1.1
+                - MultiBus Hosted Service registration fixed
+            3.1.0
+                - MultiBus Support Added
+            3.0.4
+                -Health Check with IConnection
+            3.0.3
+                -Buggy Rabbitmq healthcheck removed temporarily, will be fixed in a later version
+            3.0.2
+                -Added Health Check
+            3.0.1
+                -Recovered the port settings feature from 2.0.8
+            3.0.0
+                -MassTransit 7.1.5 support added
+            2.1.0
+                -MassTransit 6.3.1 support added. Use this version, if MassTransit 6.3.1 required in your project.
+            2.0.8
+                -Port Issue fixed (RabbitMQ started using the port number in settings.)
+            2.0.7
+                -Prefetch Count Added
+                  
+        </Description>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 	</PropertyGroup>
 

--- a/Carbon.MassTransit/IServiceCollectionConfiguratorExtensions.cs
+++ b/Carbon.MassTransit/IServiceCollectionConfiguratorExtensions.cs
@@ -101,13 +101,7 @@ namespace Carbon.MassTransit
 
             if (massTransitSettings.BusType == MassTransitBusType.RabbitMQ)
             {
-                if (massTransitSettings.RabbitMq == null)
-                    throw new ArgumentNullException(nameof(massTransitSettings.RabbitMq));
-
-                var busSettings = massTransitSettings.RabbitMq;
-                serviceCollection.UsingRabbitMq((cfg, x) => rabbitMqBusFactory(configurator, busSettings, cfg, x));
-
-                serviceCollection.Collection.AddRabbitMqBusHealthCheck($"amqp://{busSettings.Username}:{busSettings.Password}@{busSettings.Host}:{busSettings.Port}{busSettings.VirtualHost}", HealthStatus.Unhealthy, healthCheckTag);
+                serviceCollection.AddRabbitMqBus(massTransitSettings.RabbitMq, configurator, healthCheckTag);
             }
         }
 
@@ -133,17 +127,8 @@ namespace Carbon.MassTransit
 
             if (massTransitSettings.BusType == MassTransitBusType.RabbitMQ)
             {
-                if (massTransitSettings.RabbitMq == null)
-                    throw new ArgumentNullException(nameof(massTransitSettings.RabbitMq));
 
-                var busSettings = massTransitSettings.RabbitMq;
-
-                serviceCollection.UsingRabbitMq((cfg, x) => rabbitMqBusFactory(configurator, busSettings, cfg, x));
-
-                if(string.IsNullOrEmpty(healthCheckTag))
-                    healthCheckTag = typeof(T).Name;
-
-                serviceCollection.Collection.AddRabbitMqBusHealthCheck($"amqp://{busSettings.Username}:{busSettings.Password}@{busSettings.Host}:{busSettings.Port}{busSettings.VirtualHost}", name: healthCheckTag);
+                serviceCollection.AddRabbitMqBus<T>(massTransitSettings.RabbitMq, configurator, healthCheckTag);
             }
         }
 
@@ -233,10 +218,7 @@ namespace Carbon.MassTransit
 
             if (massTransitSettings.BusType == MassTransitBusType.AzureServiceBus)
             {
-                if (massTransitSettings.ServiceBus == null)
-                    throw new ArgumentNullException(nameof(massTransitSettings.ServiceBus));
-
-                serviceCollection.AddBus(cfg => serviceBusFactory(configurator, massTransitSettings.ServiceBus, cfg));
+                serviceCollection.AddServiceBus(massTransitSettings.ServiceBus, configurator);
             }
         }
 
@@ -260,10 +242,7 @@ namespace Carbon.MassTransit
 
             if (massTransitSettings.BusType == MassTransitBusType.AzureServiceBus)
             {
-                if (massTransitSettings.ServiceBus == null)
-                    throw new ArgumentNullException(nameof(massTransitSettings.ServiceBus));
-
-                serviceCollection.AddBus(cfg => serviceBusFactory(configurator, massTransitSettings.ServiceBus, cfg));
+                serviceCollection.AddServiceBus<T>(massTransitSettings.ServiceBus, configurator);
             }
         }
 


### PR DESCRIPTION
## Version 3.8.0
- It is now possible to supply custom configuration objects to AddRabbitMqBus and AddServiceBus extensions.
- It is now possible to give custom health check tags to AddRabbitMqBus extensions (helps in avoiding duplicates).