### PR TITLE
Fix: Handle Null PropInfo in OrderBy Method

### DIFF
--- a/Carbon.Common/Carbon.Common.csproj
+++ b/Carbon.Common/Carbon.Common.csproj
@@ -2,8 +2,10 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <Version>1.3.3</Version>
+    <Version>1.3.4</Version>
 	  <Description>
+		  1.3.4
+		  - IQueryable OrderBy extension method bug fixed
 		  1.3.3
 		  - Enhance deep property sorting in OrderBy
 		  - Added case-insensitive property lookup and multi-level access.

--- a/Carbon.Common/IQueryableExtensions.cs
+++ b/Carbon.Common/IQueryableExtensions.cs
@@ -58,6 +58,8 @@ namespace Carbon.Common
                     selector = Expression.Property(selector, propInfo);
                 }
 
+                if (selector == parameter) continue;
+
                 var lambda = Expression.Lambda(selector, parameter);
 
                 var methodName = item.IsAscending ? "OrderBy" : "OrderByDescending";

--- a/Carbon.ConsoleApplication.Extensions/Carbon.ConsoleApplication.csproj
+++ b/Carbon.ConsoleApplication.Extensions/Carbon.ConsoleApplication.csproj
@@ -5,10 +5,10 @@
     <ApplicationIcon />
     <OutputType>Library</OutputType>
     <StartupObject />
-    <Version>1.3.2</Version>
-    <AssemblyVersion>1.3.2.0</AssemblyVersion>
-    <FileVersion>1.3.2.0</FileVersion>
+    <Version>1.3.3</Version>
     <Description>
+		1.3.3
+		- Carbon.Common updated and IQueryable OrderBy extension method bug fixed
 		1.3.2
 		- Carbon.Common updated and nested ordering achieved
 		1.3.1

--- a/Carbon.Domain.Abstractions/Carbon.Domain.Abstractions.csproj
+++ b/Carbon.Domain.Abstractions/Carbon.Domain.Abstractions.csproj
@@ -2,8 +2,10 @@
 
 	<PropertyGroup>
 		<TargetFramework>netstandard2.1</TargetFramework>
-		<Version>1.4.1</Version>
+		<Version>1.4.2</Version>
 		<Description>
+			1.4.2
+			- Carbon.Common updated and IQueryable OrderBy extension method bug fixed
 			1.4.1
 			- Carbon.Common updated and nested ordering achieved
 			1.4.0

--- a/Carbon.ElasticSearch.Abstractions/Carbon.ElasticSearch.Abstractions.csproj
+++ b/Carbon.ElasticSearch.Abstractions/Carbon.ElasticSearch.Abstractions.csproj
@@ -3,8 +3,10 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <ProjectGuid>{bdcf1c00-d0d9-4328-8817-4d093f30cee1}</ProjectGuid>
-    <Version>3.5.1</Version>
+    <Version>3.5.2</Version>
     <Description>
+		3.5.2
+		- Carbon.Common updated and IQueryable OrderBy extension method bug fixed
 		3.5.1
 		- Carbon.Common updated and nested ordering achieved
 		3.5.0

--- a/Carbon.ElasticSearch/Carbon.ElasticSearch.csproj
+++ b/Carbon.ElasticSearch/Carbon.ElasticSearch.csproj
@@ -3,8 +3,10 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <ProjectGuid>{7AEAD788-E78D-4825-9761-AEB2570DE3E0}</ProjectGuid>
-    <Version>3.5.1</Version>
+    <Version>3.5.2</Version>
     <Description>
+		3.5.2
+		- Carbon.Common updated and IQueryable OrderBy extension method bug fixed
 		3.5.1
 		- Carbon.Common updated and nested ordering achieved
 		3.5.0

--- a/Carbon.HttpClient.Auth/Carbon.HttpClient.Auth.csproj
+++ b/Carbon.HttpClient.Auth/Carbon.HttpClient.Auth.csproj
@@ -2,11 +2,12 @@
 
 	<PropertyGroup>
 		<TargetFramework>netstandard2.1</TargetFramework>
-		<Version>1.0.2</Version>
-		<AssemblyVersion>1.0.2</AssemblyVersion>
-		<Description></Description>
-		<FileVersion>1.0.2</FileVersion>
+		<Version>1.0.3</Version>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+		<Description>
+			1.0.3
+			- Carbon.Common updated and IQueryable OrderBy extension method bug fixed
+		</Description>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Carbon.HttpClient/Carbon.HttpClient.csproj
+++ b/Carbon.HttpClient/Carbon.HttpClient.csproj
@@ -1,17 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>netcoreapp3.1</TargetFramework>
+		<Version>1.0.10</Version>
+		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+		<Description>
+			1.0.10
+			- Carbon.Common updated and IQueryable OrderBy extension method bug fixed
+		</Description>
+	</PropertyGroup>
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Version>1.0.9</Version>
-    <FileVersion>1.0.9.0</FileVersion>
-    <AssemblyVersion>1.0.9.0</AssemblyVersion>
-    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.HeaderPropagation" Version="3.1.1" />
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-
-  </ItemGroup>
-
+	<ItemGroup>
+		<PackageReference Include="Microsoft.AspNetCore.HeaderPropagation" Version="3.1.1" />
+		<FrameworkReference Include="Microsoft.AspNetCore.App" />
+	</ItemGroup>
 </Project>

--- a/Carbon.PagedList.Mapster/Carbon.PagedList.Mapster.csproj
+++ b/Carbon.PagedList.Mapster/Carbon.PagedList.Mapster.csproj
@@ -1,17 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>netstandard2.1</TargetFramework>
+		<Version>1.0.10</Version>
+		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+		<Description>
+			1.0.10
+			- Carbon.Common updated and IQueryable OrderBy extension method bug fixed
+		</Description>
+	</PropertyGroup>
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
-    <Version>1.0.9</Version>
-    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-  </PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="Mapster" Version="4.1.1" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Mapster" Version="4.1.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\Carbon.PagedList\Carbon.PagedList.csproj" />
-  </ItemGroup>
-
+	<ItemGroup>
+		<ProjectReference Include="..\Carbon.PagedList\Carbon.PagedList.csproj" />
+	</ItemGroup>
 </Project>

--- a/Carbon.TimeSeriesDb.Abstractions/Carbon.TimeSeriesDb.Abstractions.csproj
+++ b/Carbon.TimeSeriesDb.Abstractions/Carbon.TimeSeriesDb.Abstractions.csproj
@@ -2,8 +2,10 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <Version>1.0.4</Version>
+    <Version>1.0.5</Version>
     <Description>
+		1.0.5
+		- Carbon.Common updated and IQueryable OrderBy extension method bug fixed
 		1.0.4
 		- Carbon.Common updated and nested ordering achieved
 		1.0.3

--- a/Carbon.WebApplication/Carbon.WebApplication.csproj
+++ b/Carbon.WebApplication/Carbon.WebApplication.csproj
@@ -1,8 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
-		<Version>4.1.8</Version>
+		<Version>4.1.9</Version>
 		<Description>
+			4.1.9
+			- Carbon.Common updated and IQueryable OrderBy extension method bug fixed
 			4.1.8
 			- Carbon.Common updated and nested ordering achieved
 			4.1.7


### PR DESCRIPTION
This pull request resolves a scenario in the `OrderBy` method where a `propInfo` that is `null` leads to the creation of an unintended lambda expression `(x => x)`. This PR introduces a solution to bypass the creation of the lambda expression when `propInfo` is `null`, ensuring that only valid property sorting expressions are generated.

Changes Made:

- Added a null check for propInfo within the inner loop. 
- Skipped the creation of the lambda expression if propInfo is null. 
- Improved code clarity and maintainability.

