### PR TITLE
 OwnershipFilter check now disregards any solution id header

### DIFF
--- a/Carbon.WebApplication/Carbon.WebApplication.csproj
+++ b/Carbon.WebApplication/Carbon.WebApplication.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
-		<Version>4.2.2</Version>
+		<Version>4.3.0</Version>
 		<Description>
-			4.2.2
+			4.3.0
 			- OwnershipFilter check now disregards solution id header during endpoint permission check
 			4.2.1
 			- UnauthorizedOperationException response body is fixed

--- a/Carbon.WebApplication/Carbon.WebApplication.csproj
+++ b/Carbon.WebApplication/Carbon.WebApplication.csproj
@@ -1,8 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
-		<Version>4.2.1</Version>
+		<Version>4.2.2</Version>
 		<Description>
+			4.2.2
+			- OwnershipFilter check now disregards solution id header during endpoint permission check
 			4.2.1
 			- UnauthorizedOperationException response body is fixed
 			4.2.0

--- a/Carbon.WebApplication/TenantManagementHandler/ControllerAttributes/OwnershipFilter.cs
+++ b/Carbon.WebApplication/TenantManagementHandler/ControllerAttributes/OwnershipFilter.cs
@@ -47,7 +47,7 @@ namespace Carbon.WebApplication.TenantManagementHandler.ControllerAttributes
         public override void OnActionExecuting(ActionExecutingContext context)
         {
             var _externalService = context.HttpContext.RequestServices.GetService<IExternalService>();
-            var solutions = context.GetSolutionFilter();
+            //var solutions = context.GetSolutionFilter();
             var userId = ((CarbonController)context.Controller).User.GetUserId();
             var tenantId = ((CarbonController)context.Controller).User.GetTenantId();
             var organizationId = ((CarbonController)context.Controller).User.GetOrganizationId();
@@ -62,11 +62,19 @@ namespace Carbon.WebApplication.TenantManagementHandler.ControllerAttributes
             if (isGodUser)
                 return;
 
-            if (solutions == null || !solutions.Any())
-                throw new ForbiddenOperationException(CarbonExceptionMessages.SolutionHeaderMustBeSet);
+            //if (solutions == null || !solutions.Any())
+            //    throw new ForbiddenOperationException(CarbonExceptionMessages.SolutionHeaderMustBeSet);
 
 
-            filterOwnershipPermissionList = _externalService.ExecuteInPolicyApi_GetRoles(new PermissionDetailedFilterDto() { TenantId = tenantId, UserPolicyId = organizationId, UserId = userId, SolutionId = solutions.FirstOrDefault(), PermissionNames = new List<string>() { _role } }, daToken.ToString().Split(' ')[1]).Result;
+            filterOwnershipPermissionList = _externalService.ExecuteInPolicyApi_GetRoles(new PermissionDetailedFilterDto() 
+                { 
+                    TenantId = tenantId, 
+                    UserPolicyId = organizationId, 
+                    UserId = userId, 
+                    SolutionId = null, 
+                    PermissionNames = new List<string>() { _role } 
+                }, daToken.ToString().Split(' ')[1]).Result;
+
             RoleExtensions.SetPermissions(filterOwnershipPermissionList);
 
             if (_ownershipType == OwnershipType.Admin)


### PR DESCRIPTION
We are now sending solutionId as null when checking endpoint permissions. This way we can also check if the related permission is coming from a solution other than the solution that actually sent the main request