### PR TITLE
TryAlternativeDeserialization method added

### DIFF
--- a/Carbon.Redis/Abstractions/ICarbonCacheExtensions.cs
+++ b/Carbon.Redis/Abstractions/ICarbonCacheExtensions.cs
@@ -219,6 +219,11 @@ namespace Carbon.Caching.Abstractions
                 {
                     HashEntry hashEntry = new HashEntry(HashData, result.ToByteArray(CarbonContentSerializationType.Json));
                     await instance.GetDatabase().HashSetAsync(key.ToRedisInstanceKey(instance), new HashEntry[] { hashEntry });
+                    var ttl = instance.GetDatabase().KeyTimeToLive(key);
+                    if (ttl.HasValue && ttl != TimeSpan.Zero)
+                    {
+                        await instance.SetTTL(key, (TimeSpan)ttl);
+                    }
                 }
             }
 
@@ -728,6 +733,7 @@ namespace Carbon.Caching.Abstractions
 
         #endregion
 
+        //This method added to convert binary serialized keys to json serialized, will be removed after conversion.
         public static T TryAlternativeDeserialization<T>(byte[] value) where T : class
         {
             T result;

--- a/Carbon.Redis/Carbon.Redis.csproj
+++ b/Carbon.Redis/Carbon.Redis.csproj
@@ -3,8 +3,11 @@
   <PropertyGroup>
 	 <TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
 	 <LangVersion>latest</LangVersion>
-	 <Version>2.7.1</Version>
+	 <Version>2.8.0</Version>
      <Description>
+		 2.8.0
+		 Keys can be fetched in both binary and json formatter serialized, but can only be set in json formatter serialized to transform binary formatter serialized keys which is unsupported.
+
 		 2.7.1
 		 Added try-catch expression to prevent data loss when converting binary formatter to json formatter.
 

--- a/Carbon.Redis/Extensions/SerializationExtensions.cs
+++ b/Carbon.Redis/Extensions/SerializationExtensions.cs
@@ -60,7 +60,7 @@ namespace Carbon.Caching.Abstractions.Extensions
             }
             catch(JsonException)
             {
-                throw;
+                return default(T);
             }
         }
 


### PR DESCRIPTION
Keys can be fetched in both binary and json formatter serialized, but can only be set in json formatter serialized to transform binary formatter serialized keys which is unsupported.