### PR TITLE
feat: add ownertype none in ownership filters

### DIFF
--- a/Carbon.Domain.EntityFrameworkCore.Extensions/Carbon.Domain.EntityFrameworkCore.csproj
+++ b/Carbon.Domain.EntityFrameworkCore.Extensions/Carbon.Domain.EntityFrameworkCore.csproj
@@ -2,8 +2,11 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>net6.0;net5.0;netstandard2.1</TargetFrameworks>
-		<Version>3.1.1</Version>
+		<Version>3.1.2</Version>
 		<Description>
+			- 3.1.2
+			* Refactor ownership filtering logic; include 'OwnerType.None' in conditions for more comprehensive permission assessment.
+			
 			- 3.1.1
 			* Fixed EFExtensions FirstOrDefaultEntity methods. Null check condition is added for the Relation object
 

--- a/Carbon.Domain.EntityFrameworkCore.Extensions/EFExtensions.cs
+++ b/Carbon.Domain.EntityFrameworkCore.Extensions/EFExtensions.cs
@@ -267,11 +267,11 @@ namespace Carbon.Domain.EntityFrameworkCore
             {
                 if (rp.PrivilegeLevelType == PermissionGroupImpactLevel.OnlyPolicyItself || rp.PrivilegeLevelType == PermissionGroupImpactLevel.PolicyItselfAndItsChildPolicies || rp.PrivilegeLevelType == PermissionGroupImpactLevel.AllPoliciesIncludedInZone)
                 {
-                    return relationEntities.Where(k => (orgs.Contains(k.Entity.OrganizationId) && (k.Entity.OwnerType != OwnerType.Role)) || (k.Entity.OwnerType == OwnerType.Role && k.Entity.OwnerId == rp.RoleId) || (k.Entity.OrganizationId == Guid.Empty) || (k.Entity.OwnerType == OwnerType.CustomerBased));
+                    return relationEntities.Where(k => (orgs.Contains(k.Entity.OrganizationId) && (k.Entity.OwnerType != OwnerType.Role)) || (k.Entity.OwnerType == OwnerType.Role && k.Entity.OwnerId == rp.RoleId) || (k.Entity.OrganizationId == Guid.Empty) || k.Entity.OwnerType == OwnerType.CustomerBased || k.Entity.OwnerType == OwnerType.None);
                 }
                 else if (rp.PrivilegeLevelType == PermissionGroupImpactLevel.User)
                 {
-                    return relationEntities.Where(k => k.Entity.OwnerType == OwnerType.User && k.Entity.OwnerId == rp.UserId || (k.Entity.OwnerType == OwnerType.Role && k.Entity.OwnerId == rp.RoleId) || (k.Entity.OwnerType == OwnerType.CustomerBased));
+                    return relationEntities.Where(k => k.Entity.OwnerType == OwnerType.User && k.Entity.OwnerId == rp.UserId || (k.Entity.OwnerType == OwnerType.Role && k.Entity.OwnerId == rp.RoleId) || k.Entity.OwnerType == OwnerType.CustomerBased || k.Entity.OwnerType == OwnerType.None);
                 }
             }
             return relationEntities;
@@ -292,11 +292,11 @@ namespace Carbon.Domain.EntityFrameworkCore
             {
                 if (rp.PrivilegeLevelType == PermissionGroupImpactLevel.OnlyPolicyItself || rp.PrivilegeLevelType == PermissionGroupImpactLevel.PolicyItselfAndItsChildPolicies || rp.PrivilegeLevelType == PermissionGroupImpactLevel.AllPoliciesIncludedInZone)
                 {
-                    return relationEntities.Where(k => (orgs.Contains(k.Entity.OrganizationId) && (k.Entity.OwnerType != OwnerType.Role)) || (k.Entity.OwnerType == OwnerType.Role && k.Entity.OwnerId == rp.RoleId) || (k.Entity.OrganizationId == Guid.Empty) || (k.Entity.OwnerType == OwnerType.CustomerBased));
+                    return relationEntities.Where(k => (orgs.Contains(k.Entity.OrganizationId) && (k.Entity.OwnerType != OwnerType.Role)) || (k.Entity.OwnerType == OwnerType.Role && k.Entity.OwnerId == rp.RoleId) || (k.Entity.OrganizationId == Guid.Empty) || k.Entity.OwnerType == OwnerType.CustomerBased || k.Entity.OwnerType == OwnerType.None);
                 }
                 else if (rp.PrivilegeLevelType == PermissionGroupImpactLevel.User)
                 {
-                    return relationEntities.Where(k => k.Entity.OwnerType == OwnerType.User && k.Entity.OwnerId == rp.UserId || (k.Entity.OwnerType == OwnerType.Role && k.Entity.OwnerId == rp.RoleId) || (k.Entity.OwnerType == OwnerType.CustomerBased));
+                    return relationEntities.Where(k => k.Entity.OwnerType == OwnerType.User && k.Entity.OwnerId == rp.UserId || (k.Entity.OwnerType == OwnerType.Role && k.Entity.OwnerId == rp.RoleId) || k.Entity.OwnerType == OwnerType.CustomerBased || k.Entity.OwnerType == OwnerType.None);
                 }
             }
             return relationEntities;
@@ -316,11 +316,11 @@ namespace Carbon.Domain.EntityFrameworkCore
             {
                 if (rp.PrivilegeLevelType == PermissionGroupImpactLevel.OnlyPolicyItself || rp.PrivilegeLevelType == PermissionGroupImpactLevel.PolicyItselfAndItsChildPolicies || rp.PrivilegeLevelType == PermissionGroupImpactLevel.AllPoliciesIncludedInZone)
                 {
-                    return relationEntities.Where(k => (orgs.Contains(k.OrganizationId) && (k.OwnerType != OwnerType.Role)) || (k.OwnerType == OwnerType.Role && k.OwnerId == rp.RoleId) || (k.OrganizationId == Guid.Empty) || (k.OwnerType == OwnerType.CustomerBased));
+                    return relationEntities.Where(k => (orgs.Contains(k.OrganizationId) && (k.OwnerType != OwnerType.Role)) || (k.OwnerType == OwnerType.Role && k.OwnerId == rp.RoleId) || (k.OrganizationId == Guid.Empty) || k.OwnerType == OwnerType.CustomerBased || k.OwnerType == OwnerType.None);
                 }
                 else if (rp.PrivilegeLevelType == PermissionGroupImpactLevel.User)
                 {
-                    return relationEntities.Where(k => k.OwnerType == OwnerType.User && k.OwnerId == rp.UserId || (k.OwnerType == OwnerType.Role && k.OwnerId == rp.RoleId) || (k.OwnerType == OwnerType.CustomerBased));
+                    return relationEntities.Where(k => k.OwnerType == OwnerType.User && k.OwnerId == rp.UserId || (k.OwnerType == OwnerType.Role && k.OwnerId == rp.RoleId) || k.OwnerType == OwnerType.CustomerBased || k.OwnerType == OwnerType.None);
                 }
             }
             return relationEntities;
@@ -339,11 +339,11 @@ namespace Carbon.Domain.EntityFrameworkCore
             {
                 if (rp.PrivilegeLevelType == PermissionGroupImpactLevel.OnlyPolicyItself || rp.PrivilegeLevelType == PermissionGroupImpactLevel.PolicyItselfAndItsChildPolicies || rp.PrivilegeLevelType == PermissionGroupImpactLevel.AllPoliciesIncludedInZone)
                 {
-                    return relationEntities.Where(k => (orgs.Contains(k.OrganizationId) && (k.OwnerType != OwnerType.Role)) || (k.OwnerType == OwnerType.Role && k.OwnerId == rp.RoleId) || (k.OrganizationId == Guid.Empty) || (k.OwnerType == OwnerType.CustomerBased));
+                    return relationEntities.Where(k => (orgs.Contains(k.OrganizationId) && (k.OwnerType != OwnerType.Role)) || (k.OwnerType == OwnerType.Role && k.OwnerId == rp.RoleId) || (k.OrganizationId == Guid.Empty) || k.OwnerType == OwnerType.CustomerBased || k.OwnerType == OwnerType.None);
                 }
                 else if (rp.PrivilegeLevelType == PermissionGroupImpactLevel.User)
                 {
-                    return relationEntities.Where(k => k.OwnerType == OwnerType.User && k.OwnerId == rp.UserId || (k.OwnerType == OwnerType.Role && k.OwnerId == rp.RoleId) || (k.OwnerType == OwnerType.CustomerBased));
+                    return relationEntities.Where(k => k.OwnerType == OwnerType.User && k.OwnerId == rp.UserId || (k.OwnerType == OwnerType.Role && k.OwnerId == rp.RoleId) || k.OwnerType == OwnerType.CustomerBased || k.OwnerType == OwnerType.None);
                 }
             }
             return relationEntities;

--- a/Carbon.WebApplication.EntityFrameworkCore/Carbon.WebApplication.EntityFrameworkCore.csproj
+++ b/Carbon.WebApplication.EntityFrameworkCore/Carbon.WebApplication.EntityFrameworkCore.csproj
@@ -2,8 +2,11 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net5.0;netstandard2.1</TargetFrameworks>
-    <Version>2.3.2</Version>
+    <Version>2.3.3</Version>
     <Description>
+		2.3.3
+		Upgrade Carbon.Domain.EntityFramework version (Added OwnerType.None in ownership filter)
+
 		2.3.2
 		Fixed EFExtensions FirstOrDefaultEntity methods. Null check condition is added for the Relation object
 

--- a/Carbon.WebApplication.EntityFrameworkCore/Carbon.WebApplication.EntityFrameworkCore.csproj
+++ b/Carbon.WebApplication.EntityFrameworkCore/Carbon.WebApplication.EntityFrameworkCore.csproj
@@ -2,11 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net5.0;netstandard2.1</TargetFrameworks>
-    <Version>2.3.3</Version>
+    <Version>2.3.2</Version>
     <Description>
-		2.3.3
-		Upgrade Carbon.Domain.EntityFramework version (Added OwnerType.None in ownership filter)
-		
 		2.3.2
 		Fixed EFExtensions FirstOrDefaultEntity methods. Null check condition is added for the Relation object
 

--- a/Carbon.WebApplication.EntityFrameworkCore/Carbon.WebApplication.EntityFrameworkCore.csproj
+++ b/Carbon.WebApplication.EntityFrameworkCore/Carbon.WebApplication.EntityFrameworkCore.csproj
@@ -2,8 +2,11 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net5.0;netstandard2.1</TargetFrameworks>
-    <Version>2.3.2</Version>
+    <Version>2.3.3</Version>
     <Description>
+		2.3.3
+		Upgrade Carbon.Domain.EntityFramework version (Added OwnerType.None in ownership filter)
+		
 		2.3.2
 		Fixed EFExtensions FirstOrDefaultEntity methods. Null check condition is added for the Relation object
 


### PR DESCRIPTION
Refactor ownership filtering logic; include 'OwnerType.None' in conditions for more comprehensive permission assessment.

Currently, an entity registered as OwnerType=None is not seen by any user assigned a role. The purpose of this change is to make the entity registered as None visible to everyone.