### PR TITLE
Redis Sentinel Fixes

### DIFF
--- a/Carbon.Redis/Abstractions/ICarbonCacheExtensions.cs
+++ b/Carbon.Redis/Abstractions/ICarbonCacheExtensions.cs
@@ -88,7 +88,7 @@ namespace Carbon.Caching.Abstractions
         /// <returns>Your entire object</returns>
         public static async Task<T> HashGetAsObject<T>(this ICarbonCache instance, string key) where T : class
         {
-            var values = await instance.GetDatabase().HashGetAllAsync(key.ToRedisInstanceKey(instance), CommandFlags.PreferReplica);
+            var values = await instance.GetDatabase().HashGetAllAsync(key.ToRedisInstanceKey(instance), CommandFlags.PreferMaster);
             if (values == default || !values.Any())
             {
                 return default(T);
@@ -117,7 +117,7 @@ namespace Carbon.Caching.Abstractions
             {
                 redisValues[i] = hashfields[i];
             }
-            var values = await instance.GetDatabase().HashGetAsync(key.ToRedisInstanceKey(instance), redisValues, CommandFlags.PreferReplica);
+            var values = await instance.GetDatabase().HashGetAsync(key.ToRedisInstanceKey(instance), redisValues, CommandFlags.PreferMaster);
 
             Dictionary<string, object> keyValuePairs = new Dictionary<string, object>();
             for (int i = 0; i < values.Length; i++)
@@ -211,7 +211,7 @@ namespace Carbon.Caching.Abstractions
         /// <returns>A single value for the given hash field</returns>
         public static async Task<T> HashSingleGet<T>(this ICarbonCache instance, string key) where T : class
         {
-            var value = await instance.GetDatabase().HashGetAsync(key.ToRedisInstanceKey(instance), HashData, CommandFlags.PreferReplica);
+            var value = await instance.GetDatabase().HashGetAsync(key.ToRedisInstanceKey(instance), HashData, CommandFlags.PreferMaster);
             T result = ((byte[])value).FromByteArray<T>(SerializationType);
             if (result is null)
             {
@@ -328,7 +328,7 @@ namespace Carbon.Caching.Abstractions
         /// <returns>A single value for the given hash field</returns>
         public static async Task<T> HashGet<T>(this ICarbonCache instance, string key, string hashfield) where T : class
         {
-            var value = await instance.GetDatabase().HashGetAsync(key.ToRedisInstanceKey(instance), hashfield, CommandFlags.PreferReplica);
+            var value = await instance.GetDatabase().HashGetAsync(key.ToRedisInstanceKey(instance), hashfield, CommandFlags.PreferMaster);
             return ((byte[])value).FromByteArray<T>(SerializationType);
         }
 
@@ -347,7 +347,7 @@ namespace Carbon.Caching.Abstractions
             {
                 redisValues[i] = hashfields[i];
             }
-            var values = await instance.GetDatabase().HashGetAsync(key.ToRedisInstanceKey(instance), redisValues, CommandFlags.PreferReplica);
+            var values = await instance.GetDatabase().HashGetAsync(key.ToRedisInstanceKey(instance), redisValues, CommandFlags.PreferMaster);
             Dictionary<string, T> keyValuePairs = new Dictionary<string, T>();
             for (int i = 0; i < values.Length; i++)
             {
@@ -366,7 +366,7 @@ namespace Carbon.Caching.Abstractions
         /// <returns>Dictionary of the all hash fields</returns>
         public static async Task<Dictionary<string, T>> HashGet<T>(this ICarbonCache instance, string key) where T : class
         {
-            var values = await instance.GetDatabase().HashGetAllAsync(key.ToRedisInstanceKey(instance), CommandFlags.PreferReplica);
+            var values = await instance.GetDatabase().HashGetAllAsync(key.ToRedisInstanceKey(instance), CommandFlags.PreferMaster);
             Dictionary<string, T> keyValuePairs = new Dictionary<string, T>();
             foreach (var k in values)
             {
@@ -476,7 +476,7 @@ namespace Carbon.Caching.Abstractions
         public static async Task<List<T>> SetGetMembers<T>(this ICarbonCache instance, string key)
             where T : class
         {
-            var members = await instance.GetDatabase().SetMembersAsync(key.ToRedisInstanceKey(instance), CommandFlags.PreferReplica);
+            var members = await instance.GetDatabase().SetMembersAsync(key.ToRedisInstanceKey(instance), CommandFlags.PreferMaster);
             return members.Select(k => ((byte[])k).FromByteArray<T>(SerializationType)).ToList();
         }
 
@@ -494,7 +494,7 @@ namespace Carbon.Caching.Abstractions
             List<RedisKey> redisKeys = new List<RedisKey>();
             redisKeys.AddRange(keys.ToRedisInstanceKey(instance).Select(k => new RedisKey(k)));
 
-            var combinedMembers = await instance.GetDatabase().SetCombineAsync(setOperation, redisKeys.ToArray(), CommandFlags.PreferReplica);
+            var combinedMembers = await instance.GetDatabase().SetCombineAsync(setOperation, redisKeys.ToArray(), CommandFlags.PreferMaster);
             return combinedMembers.Select(k => ((byte[])k).FromByteArray<T>(SerializationType)).ToList();
         }
 

--- a/Carbon.Redis/Carbon.Redis.csproj
+++ b/Carbon.Redis/Carbon.Redis.csproj
@@ -3,8 +3,12 @@
   <PropertyGroup>
 	 <TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
 	 <LangVersion>latest</LangVersion>
-	 <Version>2.8.2</Version>
+	 <Version>2.9.0</Version>
      <Description>
+		 2.9.0
+		 Fix: Redis Sentinel support added correctly.
+		 Feat: Degraded health status added for sentinel mode only.
+		 
 		 2.8.1
 		 Multi get async support.
 
@@ -72,7 +76,7 @@
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.11" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="6.0.11" />
     <PackageReference Include="RedLock.net" Version="2.3.2" />
-    <PackageReference Include="StackExchange.Redis" Version="2.6.70" />
+    <PackageReference Include="StackExchange.Redis" Version="2.7.17" />
     <PackageReference Include="System.Text.Json" Version="6.0.6" />
   </ItemGroup>
 

--- a/Carbon.Redis/DummyConnectionMultiplexer.cs
+++ b/Carbon.Redis/DummyConnectionMultiplexer.cs
@@ -1,4 +1,5 @@
 ﻿using StackExchange.Redis;
+using StackExchange.Redis.Maintenance;
 using StackExchange.Redis.Profiling;
 using System;
 using System.IO;
@@ -39,6 +40,7 @@ namespace Carbon.Redis
         public event EventHandler<EndPointEventArgs> ConfigurationChanged;
         public event EventHandler<EndPointEventArgs> ConfigurationChangedBroadcast;
         public event EventHandler<HashSlotMovedEventArgs> HashSlotMoved;
+        public event EventHandler<ServerMaintenanceEvent> ServerMaintenanceEvent;
 
         public void Close(bool allowCommandsToComplete = true)
         {

--- a/Carbon.Redis/DummyRedisServer.cs
+++ b/Carbon.Redis/DummyRedisServer.cs
@@ -31,6 +31,7 @@ namespace Carbon.Redis
         public bool IsReplica { get; }
 
         public bool AllowReplicaWrites { get; set; }
+        public RedisProtocol Protocol { get; }
 
         public async Task<TimeSpan> PingAsync(CommandFlags flags = CommandFlags.None)
         {
@@ -573,72 +574,72 @@ namespace Carbon.Redis
 
         public Task ReplicaOfAsync(EndPoint master, CommandFlags flags = CommandFlags.None)
         {
-            throw new NotImplementedException();
+            return default;
         }
 
         public EndPoint[] SentinelGetReplicaAddresses(string serviceName, CommandFlags flags = CommandFlags.None)
         {
-            throw new NotImplementedException();
+            return default;
         }
 
         public Task<EndPoint[]> SentinelGetReplicaAddressesAsync(string serviceName, CommandFlags flags = CommandFlags.None)
         {
-            throw new NotImplementedException();
+            return default;
         }
 
         public KeyValuePair<string, string>[][] SentinelReplicas(string serviceName, CommandFlags flags = CommandFlags.None)
         {
-            throw new NotImplementedException();
+            return default;
         }
 
         public Task<KeyValuePair<string, string>[][]> SentinelReplicasAsync(string serviceName, CommandFlags flags = CommandFlags.None)
         {
-            throw new NotImplementedException();
+            return default;
         }
 
         public Role Role(CommandFlags flags = CommandFlags.None)
         {
-            throw new NotImplementedException();
+            return default;
         }
 
         public Task<Role> RoleAsync(CommandFlags flags = CommandFlags.None)
         {
-            throw new NotImplementedException();
+            return default;
         }
 
         public long CommandCount(CommandFlags flags = CommandFlags.None)
         {
-            throw new NotImplementedException();
+            return default;
         }
 
         public Task<long> CommandCountAsync(CommandFlags flags = CommandFlags.None)
         {
-            throw new NotImplementedException();
+            return default;
         }
 
         public RedisKey[] CommandGetKeys(RedisValue[] command, CommandFlags flags = CommandFlags.None)
         {
-            throw new NotImplementedException();
+            return default;
         }
 
         public Task<RedisKey[]> CommandGetKeysAsync(RedisValue[] command, CommandFlags flags = CommandFlags.None)
         {
-            throw new NotImplementedException();
+            return default;
         }
 
         public string[] CommandList(RedisValue? moduleName = null, RedisValue? category = null, RedisValue? pattern = null, CommandFlags flags = CommandFlags.None)
         {
-            throw new NotImplementedException();
+            return default;
         }
 
         public Task<string[]> CommandListAsync(RedisValue? moduleName = null, RedisValue? category = null, RedisValue? pattern = null, CommandFlags flags = CommandFlags.None)
         {
-            throw new NotImplementedException();
+            return default;
         }
 
         public Task MakePrimaryAsync(ReplicationChangeOptions options, TextWriter log = null)
         {
-            throw new NotImplementedException();
+            return default;
         }
     }
 }

--- a/Carbon.Redis/IRedisSettings.cs
+++ b/Carbon.Redis/IRedisSettings.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Security.Authentication;
 
 namespace Carbon.Redis
 {
@@ -49,6 +50,10 @@ namespace Carbon.Redis
         /// </summary>
         string Password { get; set; }
         /// <summary>
+        /// User for the redis server (for use with ACLs on redis 6 and above)
+        /// </summary>
+        string User { get; set; }
+        /// <summary>
         /// Enables a range of commands that are considered risky
         /// </summary>
         bool AllowAdmin { get; set; }
@@ -72,7 +77,10 @@ namespace Carbon.Redis
         /// Enable if redis port uses TLS
         /// </summary>
         bool SSLEnabled { get; set; }
-
+        /// <summary>
+        /// Ssl/Tls versions supported when using an encrypted connection. Use ‘|’ to provide multiple values.
+        /// </summary>
+        SslProtocols? SslProtocols { get; set; }
         /// <summary>
         /// Sentinel Enablement
         /// </summary>

--- a/Carbon.Redis/RedisDatabase.cs
+++ b/Carbon.Redis/RedisDatabase.cs
@@ -1099,6 +1099,26 @@ namespace Carbon.Redis
             return default;
         }
 
+        public RedisResult ScriptEvaluateReadOnly(string script, RedisKey[] keys = null, RedisValue[] values = null, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public RedisResult ScriptEvaluateReadOnly(byte[] hash, RedisKey[] keys = null, RedisValue[] values = null, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public Task<RedisResult> ScriptEvaluateReadOnlyAsync(string script, RedisKey[] keys = null, RedisValue[] values = null, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
+        public Task<RedisResult> ScriptEvaluateReadOnlyAsync(byte[] hash, RedisKey[] keys = null, RedisValue[] values = null, CommandFlags flags = CommandFlags.None)
+        {
+            return default;
+        }
+
         public bool SetAdd(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None)
         {
             return default;

--- a/Carbon.Redis/RedisSettings.cs
+++ b/Carbon.Redis/RedisSettings.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Options;
 using System.Collections.Generic;
+using System.Security.Authentication;
 
 namespace Carbon.Redis
 {
@@ -19,6 +20,7 @@ namespace Carbon.Redis
         public int ConfigCheckSeconds { get; set; }
         public HashSet<string> CommandMap { get; set; }
         public string Password { get; set; }
+        public string Name { get; set; }
         public bool AllowAdmin { get; set; }
         public bool CommandMapAvailable { get; set; }
         public int AsyncTimeout { get; set; }
@@ -26,6 +28,7 @@ namespace Carbon.Redis
         public int ConnectTimeout { get; set; }
         public int DefaultDatabase { get; set; }
         public bool SSLEnabled { get; set; }
+        public SslProtocols? SslProtocols { get; set; } 
         public string InstanceName { get; set; }
         public string SentinelServiceName { get; set; }
         public int SyncTimeout { get; set; }

--- a/Carbon.Redis/ServiceCollectionExtensions.cs
+++ b/Carbon.Redis/ServiceCollectionExtensions.cs
@@ -11,8 +11,11 @@ using StackExchange.Redis;
 
 using System;
 using System.Linq;
+using System.Net.Security;
 using System.Security.Cryptography;
 using System.Text;
+
+using static StackExchange.Redis.Role;
 
 namespace Carbon.Redis
 {
@@ -72,7 +75,7 @@ namespace Carbon.Redis
                     ConfigurationChannel = redisSettings.Value.ConfigurationChannel,
                     TieBreaker = redisSettings.Value.TieBreaker,
                     ConfigCheckSeconds = redisSettings.Value.ConfigCheckSeconds,
-                    CommandMap = CommandMap.Create(redisSettings.Value.CommandMap, available: redisSettings.Value.CommandMapAvailable),
+                    CommandMap = redisSettings.Value.CommandMap != null && redisSettings.Value.CommandMap.Any() ? CommandMap.Create(redisSettings.Value.CommandMap, available: redisSettings.Value.CommandMapAvailable) : CommandMap.Default,
                     Password = redisSettings.Value.Password,
                     AllowAdmin = redisSettings.Value.AllowAdmin,
                     AsyncTimeout = redisSettings.Value.AsyncTimeout,
@@ -81,50 +84,66 @@ namespace Carbon.Redis
                     DefaultDatabase = redisSettings.Value.DefaultDatabase,
                     Ssl = redisSettings.Value.SSLEnabled,
                     ServiceName = redisSettings.Value.SentinelServiceName,
-                    SyncTimeout = redisSettings.Value.SyncTimeout
+                    SyncTimeout = redisSettings.Value.SyncTimeout,
+                    Protocol = RedisProtocol.Resp2
+                    //CheckCertificateRevocation = false
                 };
+                //configurationOptions.CertificateValidation += ConfigurationOptions_CertificateValidation;
 
                 if (!String.IsNullOrEmpty(redisSettings.Value.User))
                     configurationOptions.User = redisSettings.Value.User;
 
                 if (redisSettings.Value.SSLEnabled)
                 {
-                    configurationOptions.SslProtocols = System.Security.Authentication.SslProtocols.None;
+                    if (redisSettings.Value.SslProtocols.HasValue)
+                        configurationOptions.SslProtocols = redisSettings.Value.SslProtocols.Value;
+                    else
+                        configurationOptions.SslProtocols = System.Security.Authentication.SslProtocols.None;
                 }
 
-                var redis = ConnectionMultiplexer.Connect(configurationOptions);
-                if (redis.IsConnected)
+                services.AddSingleton<ConfigurationOptions>(configurationOptions);
+                if (!String.IsNullOrEmpty(configurationOptions.ServiceName))
                 {
-                    services.AddSingleton<ConfigurationOptions>(configurationOptions);
-                    services.AddSingleton<IConnectionMultiplexer>(redis);
-                    var db = redis.GetDatabase(redisSettings.Value.DefaultDatabase);
-                    services.AddSingleton(s => db);
-                    RedisHelper.SetRedisKeyLength(redisSettings.Value.KeyLength);
-
-                    if (!String.IsNullOrEmpty(configurationOptions.ServiceName))
+                    var sentinelConfig = configurationOptions.Clone();
+                    var secondsOfTimeOut = 1000;//1 seconds, if the value becomes lower than a second, it can cause errors.
+                    sentinelConfig.SyncTimeout = sentinelConfig.SyncTimeout < secondsOfTimeOut ? secondsOfTimeOut : sentinelConfig.SyncTimeout;
+                    sentinelConfig.AsyncTimeout = sentinelConfig.AsyncTimeout < secondsOfTimeOut ? secondsOfTimeOut : sentinelConfig.AsyncTimeout;
+                    sentinelConfig.CommandMap = CommandMap.Sentinel;
+                    SentinelConnectionMultiplexer redisSentinel = new SentinelConnectionMultiplexer(ConnectionMultiplexer.SentinelConnect(sentinelConfig));
+                    if (redisSentinel.ConnectionMultiplexer.IsConnected)
                     {
-                        var sentinelConfig = configurationOptions.Clone();
-                        var SecondsOfTimeOut = 10000;
-                        sentinelConfig.SyncTimeout = SecondsOfTimeOut;
-                        sentinelConfig.AsyncTimeout = SecondsOfTimeOut;
-                        SentinelConnectionMultiplexer redisSentinel = new SentinelConnectionMultiplexer(ConnectionMultiplexer.SentinelConnect(sentinelConfig));
-                        if (redisSentinel.ConnectionMultiplexer.IsConnected)
-                        {
-                            services.AddSingleton<ISentinelConnectionMultiplexer>(redisSentinel);
-                        }
+                        var master = redisSentinel.ConnectionMultiplexer.GetSentinelMasterConnection(configurationOptions);
+                        services.AddSingleton<IConnectionMultiplexer>(master);
+                        var db = master.GetDatabase(redisSettings.Value.DefaultDatabase);
+                        services.AddSingleton(s => db);
+                        RedisHelper.SetRedisKeyLength(redisSettings.Value.KeyLength);
+                        services.AddSingleton<ISentinelConnectionMultiplexer>(redisSentinel);
                     }
                     else
                     {
-                        NonSentinelConnectionMultiplexer redisSentinel = new NonSentinelConnectionMultiplexer(redis);
-                        services.AddSingleton<ISentinelConnectionMultiplexer>(redisSentinel);
+                        throw new RedisConnectionException(ConnectionFailureType.UnableToConnect, ConnectionFailureType.UnableToConnect.ToString());
                     }
-
-                    services.AddHealthChecks().AddCheck<CustomRedisHealthCheck>("RedisConnectionCheck", HealthStatus.Unhealthy);
                 }
                 else
                 {
-                    throw new RedisConnectionException(ConnectionFailureType.UnableToConnect, ConnectionFailureType.UnableToConnect.ToString());
+                    var redis = ConnectionMultiplexer.Connect(configurationOptions);
+                    if (redis.IsConnected)
+                    {
+                        services.AddSingleton<IConnectionMultiplexer>(redis);
+                        var db = redis.GetDatabase(redisSettings.Value.DefaultDatabase);
+                        services.AddSingleton(s => db);
+                        RedisHelper.SetRedisKeyLength(redisSettings.Value.KeyLength);
+                        NonSentinelConnectionMultiplexer redisSentinel = new NonSentinelConnectionMultiplexer(redis);
+                        services.AddSingleton<ISentinelConnectionMultiplexer>(redisSentinel);
+
+                    }
+                    else
+                    {
+                        throw new RedisConnectionException(ConnectionFailureType.UnableToConnect, ConnectionFailureType.UnableToConnect.ToString());
+                    }
                 }
+                services.AddHealthChecks().AddCheck<CustomRedisHealthCheck>("RedisConnectionCheck", HealthStatus.Unhealthy);
+                
             }
             else
             {
@@ -132,8 +151,18 @@ namespace Carbon.Redis
                 services.AddSingleton<IConnectionMultiplexer, DummyConnectionMultiplexer>();
             }
 
-
+            
             return new CarbonRedisBuilder(services, configurationOptions, configuration);
+        }
+
+        private static bool ConfigurationOptions_CertificateValidation(object sender, System.Security.Cryptography.X509Certificates.X509Certificate certificate, System.Security.Cryptography.X509Certificates.X509Chain chain, System.Net.Security.SslPolicyErrors sslPolicyErrors)
+        {
+            if (sslPolicyErrors == SslPolicyErrors.None)
+                return true;
+
+            Console.WriteLine("Certificate error: {0}", sslPolicyErrors);
+
+            return false;
         }
 
         /// <summary>

--- a/Carbon.WebApplication.Grpc/Carbon.WebApplication.Grpc.csproj
+++ b/Carbon.WebApplication.Grpc/Carbon.WebApplication.Grpc.csproj
@@ -2,8 +2,10 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
-    <Version>3.1.0</Version>
+    <Version>3.2.0</Version>
     <Description>
+		3.2.0
+		- Degraded health check HTTP status code changed as custom 218 (This Is Fine) status code. Because even if system is degraed it should be working normally, so returning 5XX status code is not right for degraded state.
 		3.1.0
 		- Carbon.Common updated and Serilog.Enrichers.Sensitive Enricher added for masking sensitive values within logs.
 		3.0.2

--- a/Carbon.WebApplication.Grpc/CommonGrpcStartup.cs
+++ b/Carbon.WebApplication.Grpc/CommonGrpcStartup.cs
@@ -184,7 +184,7 @@ namespace Carbon.WebApplication.Grpc
                 ResultStatusCodes =
                     {
                         [HealthStatus.Healthy] = StatusCodes.Status200OK,
-                        [HealthStatus.Degraded] = StatusCodes.Status500InternalServerError,
+                        [HealthStatus.Degraded] = 218,
                         [HealthStatus.Unhealthy] = StatusCodes.Status503ServiceUnavailable
                     }
 

--- a/Carbon.WebApplication/Carbon.WebApplication.csproj
+++ b/Carbon.WebApplication/Carbon.WebApplication.csproj
@@ -1,8 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
-		<Version>4.4.1</Version>
+		<Version>4.5.0</Version>
 		<Description>
+			4.5.0
+			- Degraded health check HTTP status code changed as custom 218 (This Is Fine) status code. Because even if system is degraed it should be working normally, so returning 5XX status code is not right for degraded state. 
 			4.4.1
 			- Cors should come first before authentication and authorization in startup pipeline
 			4.4.0

--- a/Carbon.WebApplication/CommonStartup.cs
+++ b/Carbon.WebApplication/CommonStartup.cs
@@ -285,7 +285,7 @@ namespace Carbon.WebApplication
                 ResultStatusCodes =
                 {
                     [HealthStatus.Healthy] = StatusCodes.Status200OK,
-                    [HealthStatus.Degraded] = StatusCodes.Status500InternalServerError,
+                    [HealthStatus.Degraded] = 218,
                     [HealthStatus.Unhealthy] = StatusCodes.Status503ServiceUnavailable
                 }
 


### PR DESCRIPTION
Redis sentinel implemented correctly and degraded health check state added.

In sentinel mode, slaves becomes read-only (Generally Preferred Way) and master writes are async; so you should not write to master and try to read from slave.