### PR TITLE
feat: Add new methods to EFExtensions

### DIFF
--- a/Carbon.Common/BaseRequestPageDto.cs
+++ b/Carbon.Common/BaseRequestPageDto.cs
@@ -4,6 +4,7 @@ namespace Carbon.Common
 {
     public class BaseRequestPageDto : IOrderableDto, IPageableDto
     {
+        // TODO : Since there are differences in UI and API requests, there are 2 orderable properties. It is a development waiting to be fixed as a technical debt.
         public IList<Orderable> Ordination { set { Orderables = value; } }
         public IList<Orderable> Orderables { get; set; }
 
@@ -14,8 +15,8 @@ namespace Carbon.Common
 
         public BaseRequestPageDto()
         {
-            this.PageSize = 250;
             this.PageIndex = 1;
+            this.PageSize = 250;
             Orderables = Ordination = new List<Orderable>()
             {
                 new Orderable()

--- a/Carbon.Common/BaseRequestPageDto.cs
+++ b/Carbon.Common/BaseRequestPageDto.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+
+namespace Carbon.Common
+{
+    public class BaseRequestPageDto : IOrderableDto, IPageableDto
+    {
+        public IList<Orderable> Ordination { set { Orderables = value; } }
+        public IList<Orderable> Orderables { get; set; }
+
+        public int PageSize { get; set; }
+        public int PageIndex { get; set; }
+        public int TotalCount { get; set; }
+        public int FilteredCount { get; set; }
+
+        public BaseRequestPageDto()
+        {
+            this.PageSize = 250;
+            this.PageIndex = 1;
+            Orderables = Ordination = new List<Orderable>()
+            {
+                new Orderable()
+                {
+                    Value = "UpdatedDate",
+                    IsAscending = false,
+                }
+            };
+        }
+    }
+}

--- a/Carbon.Common/Carbon.Common.csproj
+++ b/Carbon.Common/Carbon.Common.csproj
@@ -2,8 +2,10 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <Version>1.4.0</Version>
+    <Version>1.5.0</Version>
 	  <Description>
+		  1.5.0
+		  - Added BaseRequestPageDto
 		  1.4.0
 		  - SensitiveDataMasking added to SerilogSettings.
 		  1.3.4

--- a/Carbon.Common/Carbon.Common.csproj
+++ b/Carbon.Common/Carbon.Common.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <Version>1.5.0</Version>
+    <Version>1.5.0-preview</Version>
 	  <Description>
 		  1.5.0
 		  - Added BaseRequestPageDto

--- a/Carbon.Common/Carbon.Common.csproj
+++ b/Carbon.Common/Carbon.Common.csproj
@@ -6,6 +6,7 @@
 	  <Description>
 		  1.5.0
 		  - Added BaseRequestPageDto
+		  - Added StringExtensions
 		  1.4.0
 		  - SensitiveDataMasking added to SerilogSettings.
 		  1.3.4

--- a/Carbon.Common/Extensions/StringExtensions.cs
+++ b/Carbon.Common/Extensions/StringExtensions.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace Carbon.Common.Extensions
+{
+    public static class StringExtensions
+    {
+        public static string ReplaceTurkishChars(this string str, string replacement)
+        {
+            if (string.IsNullOrEmpty(str)) return str;
+            var turkishChars = new string[] { "ı", "i", "ğ", "Ğ", "ü", "Ü", "ş", "Ş", "ö", "Ö", "ç", "Ç" };
+            var result = turkishChars.Aggregate(str, (current, turkishChar) => Regex.Replace(current, turkishChar, replacement, RegexOptions.IgnoreCase));
+            return result;
+        }
+        
+        public static bool ContainsTurkishIgnoreCase(this string source, string search)
+        {
+            if (string.IsNullOrEmpty(source) || string.IsNullOrEmpty(search))
+                return false;
+
+            source = source.ToLowerInvariant().ReplaceTurkishChars("");
+            search = search.ToLowerInvariant().ReplaceTurkishChars("");
+
+            var words = source.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+            var result = words.Any(word => word.Contains(search));
+            return result;
+        }
+    }
+}

--- a/Carbon.Domain.EntityFrameworkCore.Extensions/Carbon.Domain.EntityFrameworkCore.csproj
+++ b/Carbon.Domain.EntityFrameworkCore.Extensions/Carbon.Domain.EntityFrameworkCore.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>net6.0;net5.0;netstandard2.1</TargetFrameworks>
-		<Version>3.1.3</Version>
+		<Version>3.1.3-preview</Version>
 		<Description>
 			- 3.1.3
 			* Added new extension method to EFExtensions (ToListEntityFilteredWithIncludeAsync, ToPagedListEntityFilteredWithIncludeAsync, ToPagedListEntityAsync)

--- a/Carbon.Domain.EntityFrameworkCore.Extensions/Carbon.Domain.EntityFrameworkCore.csproj
+++ b/Carbon.Domain.EntityFrameworkCore.Extensions/Carbon.Domain.EntityFrameworkCore.csproj
@@ -2,8 +2,11 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>net6.0;net5.0;netstandard2.1</TargetFrameworks>
-		<Version>3.1.2</Version>
+		<Version>3.1.3</Version>
 		<Description>
+			- 3.1.3
+			* Added new extension method to EFExtensions (ToListEntityFilteredWithIncludeAsync, ToPagedListEntityFilteredWithIncludeAsync, ToPagedListEntityAsync)
+			
 			- 3.1.2
 			* Refactor ownership filtering logic; include 'OwnerType.None' in conditions for more comprehensive permission assessment.
 			
@@ -74,6 +77,7 @@
 	<ItemGroup>
 		<ProjectReference Include="..\Carbon.Domain.Abstractions\Carbon.Domain.Abstractions.csproj" />
 		<ProjectReference Include="..\Carbon.ExceptionHandling\Carbon.ExceptionHandling.Abstractions.csproj" />
+		<ProjectReference Include="..\Carbon.PagedList\Carbon.PagedList.csproj" />
 	</ItemGroup>
 
 </Project>

--- a/Carbon.WebApplication/Carbon.WebApplication.csproj
+++ b/Carbon.WebApplication/Carbon.WebApplication.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
-		<Version>4.5.1</Version>
+		<Version>4.5.1-preview</Version>
 		<Description>
 			4.5.1
 			- Updated Carbon.Common nuget package(Added BaseRequestPageDto class)

--- a/Carbon.WebApplication/Carbon.WebApplication.csproj
+++ b/Carbon.WebApplication/Carbon.WebApplication.csproj
@@ -4,7 +4,7 @@
 		<Version>4.5.1</Version>
 		<Description>
 			4.5.1
-			- Updated Carbon.Common nuget package(Added new EFExtension methods)
+			- Updated Carbon.Common nuget package(Added BaseRequestPageDto class)
 			4.5.0
 			- Degraded health check HTTP status code changed as custom 218 (This Is Fine) status code. Because even if system is degraed it should be working normally, so returning 5XX status code is not right for degraded state. 
 			4.4.1

--- a/Carbon.WebApplication/Carbon.WebApplication.csproj
+++ b/Carbon.WebApplication/Carbon.WebApplication.csproj
@@ -1,8 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
-		<Version>4.5.0</Version>
+		<Version>4.5.1</Version>
 		<Description>
+			4.5.1
+			- Updated Carbon.Common nuget package(Added new EFExtension methods)
 			4.5.0
 			- Degraded health check HTTP status code changed as custom 218 (This Is Fine) status code. Because even if system is degraed it should be working normally, so returning 5XX status code is not right for degraded state. 
 			4.4.1


### PR DESCRIPTION
## Description

Currently, in services using Carbon, the same codes were written over and over again to make the includes for solution migration and call the tolist method. An additional extension method has been added to shorten them. In this method, the necessary includes for owner and solution are added and the tolist extension method is called. For the same method, a alternative that will work with pagenation was also written. 

In addition, a method that makes tolist for pagination has been added. In the get all methods in the services, pagination operations were performed repeatedly. This method can be used to minimise these.


## Changelog

- Added new extension method to EFExtensions (ToListEntityFilteredWithIncludeAsync, ToPagedListEntityFilteredWithIncludeAsync, ToPagedListEntityAsync)
- Added BaseRequestPageDto in Carbon.Common