### PR TITLE
Feature/2484578/0/entity UUID to long conversion

### DIFF
--- a/Carbon.Domain.Abstractions/Carbon.Domain.Abstractions.csproj
+++ b/Carbon.Domain.Abstractions/Carbon.Domain.Abstractions.csproj
@@ -2,10 +2,10 @@
 
 	<PropertyGroup>
 		<TargetFramework>netstandard2.1</TargetFramework>
-		<Version>1.4.3</Version>
+		<Version>1.5.0</Version>
 		<Description>
-			1.4.3
-			- An IEntity object, which can be parameterized for the purpose of transforming Primary Id columns found in the product roadmap into Long, has been added.
+			1.5.0
+			- A New IEntity object, which can be parameterized for the purpose of transforming Primary Id columns found in the product roadmap into Long, has been added.
 			1.4.2
 			- Carbon.Common updated and IQueryable OrderBy extension method bug fixed
 			1.4.1

--- a/Carbon.Domain.Abstractions/Carbon.Domain.Abstractions.csproj
+++ b/Carbon.Domain.Abstractions/Carbon.Domain.Abstractions.csproj
@@ -2,8 +2,10 @@
 
 	<PropertyGroup>
 		<TargetFramework>netstandard2.1</TargetFramework>
-		<Version>1.4.2</Version>
+		<Version>1.4.3</Version>
 		<Description>
+			1.4.3
+			- An IEntity object, which can be parameterized for the purpose of transforming Primary Id columns found in the product roadmap into Long, has been added.
 			1.4.2
 			- Carbon.Common updated and IQueryable OrderBy extension method bug fixed
 			1.4.1

--- a/Carbon.Domain.Abstractions/Entities/IEntity.cs
+++ b/Carbon.Domain.Abstractions/Entities/IEntity.cs
@@ -11,13 +11,4 @@ namespace Carbon.Domain.Abstractions.Entities
         public Guid Id { get; set; }
 
     }
-
-    /// <summary>
-    /// An interface for entity objects with generic unique id.
-    /// </summary>
-    /// <typeparam name="K"></typeparam>
-    public interface IEntity<K>
-    {
-        public K Id { get; set; }
-    }
 }

--- a/Carbon.Domain.Abstractions/Entities/IEntity.cs
+++ b/Carbon.Domain.Abstractions/Entities/IEntity.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 
 namespace Carbon.Domain.Abstractions.Entities
 {
@@ -11,4 +12,12 @@ namespace Carbon.Domain.Abstractions.Entities
 
     }
 
+    /// <summary>
+    /// An interface for entity objects with generic unique id.
+    /// </summary>
+    /// <typeparam name="K"></typeparam>
+    public interface IEntity<K>
+    {
+        public K Id { get; set; }
+    }
 }

--- a/Carbon.Domain.Abstractions/Entities/IGenericKeyEntity.cs
+++ b/Carbon.Domain.Abstractions/Entities/IGenericKeyEntity.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Carbon.Domain.Abstractions.Entities
+{
+    /// <summary>
+    /// An interface for entity objects with generic unique id.
+    /// </summary>
+    /// <typeparam name="TKey"></typeparam>
+    public interface IEntity<TKey>
+    {
+        public TKey Id { get; set; }
+    }
+}


### PR DESCRIPTION
An IEntity object, which can be parameterized for the purpose of transforming Primary Id columns found in the product roadmap into Long, has been added.