### PR TITLE
fix: Carbon.PagedList validation error

### DIFF
--- a/Carbon.Domain.EntityFrameworkCore.Extensions/Carbon.Domain.EntityFrameworkCore.csproj
+++ b/Carbon.Domain.EntityFrameworkCore.Extensions/Carbon.Domain.EntityFrameworkCore.csproj
@@ -2,8 +2,11 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>net6.0;net5.0;netstandard2.1</TargetFrameworks>
-		<Version>3.1.4</Version>
+		<Version>3.1.5</Version>
 		<Description>
+			- 3.1.5
+			* Upgrade Carbon.PagedList (Remove pageSize and pageNumber validation check)
+			
 			- 3.1.3
 			* Added new extension method to EFExtensions (ToPagedListEntityFilteredWithSolution, ToPagedListEntityAsync, WhereContains)
 			

--- a/Carbon.PagedList.EntityFrameworkCore/Carbon.PagedList.EntityFrameworkCore.csproj
+++ b/Carbon.PagedList.EntityFrameworkCore/Carbon.PagedList.EntityFrameworkCore.csproj
@@ -2,7 +2,11 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <Version>1.1.2</Version>
+    <Version>1.1.3</Version>
+    <Description>
+      1.1.3
+      - Upgrade Carbon.PagedList (Remove pageSize and pageNumber validation check)
+    </Description>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
 

--- a/Carbon.PagedList.EntityFrameworkCore/PagedListExtensions.cs
+++ b/Carbon.PagedList.EntityFrameworkCore/PagedListExtensions.cs
@@ -23,20 +23,22 @@ namespace Carbon.PagedList.EntityFrameworkCore
         /// <seealso cref="PagedList{T}"/>
         public static async Task<IPagedList<T>> ToPagedListAsync<T>(this IQueryable<T> superset, int pageNumber, int pageSize)
         {
-            if (pageNumber < 1)
-                throw new ArgumentOutOfRangeException(nameof(pageNumber), pageNumber, "PageNumber cannot be below 1.");
-            if (pageSize < 1)
-                throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "PageSize cannot be less than 1.");
-
+            var isAllDataRequest = pageSize == 0 && pageNumber == 1;
+            
             var totalItemCount = superset?.Count() ?? 0;
             var result = new List<T>();
-            
+
             if (superset != null && totalItemCount > 0)
             {
-                if (pageNumber == 1)
-                    result = await superset.Skip(0).Take(pageSize).ToListAsync();
+                if (isAllDataRequest)
+                {
+                    result = await superset.ToListAsync();
+                }
                 else
-                    result = await superset.Skip((pageNumber - 1) * pageSize).Take(pageSize).ToListAsync();
+                {
+                    var skipCount = pageNumber == 1 ? 0 : (pageNumber - 1) * pageSize;
+                    result = await superset.Skip(skipCount).Take(pageSize).ToListAsync();
+                }
             }
 
             return new PagedList<T>(result, pageNumber, pageSize, totalItemCount);

--- a/Carbon.PagedList.Mapster/Carbon.PagedList.Mapster.csproj
+++ b/Carbon.PagedList.Mapster/Carbon.PagedList.Mapster.csproj
@@ -1,9 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFramework>netstandard2.1</TargetFramework>
-		<Version>1.0.10</Version>
+		<Version>1.0.11</Version>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<Description>
+			1.0.11
+			- Upgrade Carbon.PagedList (Remove pageSize and pageNumber validation check)
 			1.0.10
 			- Carbon.Common updated and IQueryable OrderBy extension method bug fixed
 		</Description>

--- a/Carbon.PagedList/BasePagedList.cs
+++ b/Carbon.PagedList/BasePagedList.cs
@@ -36,10 +36,7 @@ namespace Carbon.PagedList
         /// <param name = "totalItemCount">The size of the superset.</param>
         protected internal BasePagedList(int pageNumber, int pageSize, int totalItemCount)
         {
-            if (pageNumber < 1)
-                throw new ArgumentOutOfRangeException(nameof(pageNumber), pageNumber, "PageNumber cannot be below 1.");
-            if (pageSize < 1)
-                throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "PageSize cannot be less than 1.");
+            var isAllDataRequest = pageSize == 0 && pageNumber == 1;
 
             // set source to blank list if superset is null to prevent exceptions
             TotalItemCount = totalItemCount;
@@ -50,8 +47,8 @@ namespace Carbon.PagedList
                             : 0;
             HasPreviousPage = PageNumber > 1;
             HasNextPage = PageNumber < PageCount;
-            IsFirstPage = PageNumber == 1;
-            IsLastPage = PageNumber >= PageCount;
+            IsFirstPage = isAllDataRequest || PageNumber == 1;
+            IsLastPage = isAllDataRequest || PageNumber >= PageCount;
             FirstItemOnPage = (PageNumber - 1) * PageSize + 1;
             var numberOfLastItemOnPage = FirstItemOnPage + PageSize - 1;
             LastItemOnPage = numberOfLastItemOnPage > TotalItemCount

--- a/Carbon.PagedList/Carbon.PagedList.csproj
+++ b/Carbon.PagedList/Carbon.PagedList.csproj
@@ -2,7 +2,11 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <Version>1.1.2</Version>
+    <Version>1.1.3</Version>
+    <Description>
+      1.1.3
+      - Remove pageSize and pageNumber validation check
+    </Description>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
 

--- a/Carbon.PagedList/PagedList.cs
+++ b/Carbon.PagedList/PagedList.cs
@@ -35,10 +35,7 @@ namespace Carbon.PagedList
         /// <exception cref="ArgumentOutOfRangeException">The specified page size cannot be less than one.</exception>
         public PagedList(IEnumerable<T> subset, int pageNumber, int pageSize, int totalCount)
         {
-            if (pageNumber < 1)
-                throw new ArgumentOutOfRangeException(nameof(pageNumber), pageNumber, "PageNumber cannot be below 1.");
-            if (pageSize < 1)
-                throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "PageSize cannot be less than 1.");
+            var isAllDataRequest = pageSize == 0 && pageNumber == 1;
 
             // set source to blank list if superset is null to prevent exceptions
             TotalItemCount = totalCount;
@@ -49,8 +46,8 @@ namespace Carbon.PagedList
                         : 0;
             HasPreviousPage = PageNumber > 1;
             HasNextPage = PageNumber < PageCount;
-            IsFirstPage = PageNumber == 1;
-            IsLastPage = PageNumber >= PageCount;
+            IsFirstPage = isAllDataRequest || PageNumber == 1;
+            IsLastPage = isAllDataRequest || PageNumber >= PageCount;
             FirstItemOnPage = (PageNumber - 1) * PageSize + 1;
             var numberOfLastItemOnPage = FirstItemOnPage + PageSize - 1;
             LastItemOnPage = numberOfLastItemOnPage > TotalItemCount
@@ -72,10 +69,7 @@ namespace Carbon.PagedList
         /// <exception cref="ArgumentOutOfRangeException">The specified page size cannot be less than one.</exception>
         public PagedList(IQueryable<T> superset, int pageNumber, int pageSize)
         {
-            if (pageNumber < 1)
-                throw new ArgumentOutOfRangeException(nameof(pageNumber), pageNumber, "PageNumber cannot be below 1.");
-            if (pageSize < 1)
-                throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "PageSize cannot be less than 1.");
+            var isAllDataRequest = pageSize == 0 && pageNumber == 1;
 
             // set source to blank list if superset is null to prevent exceptions
             TotalItemCount = superset?.Count() ?? 0;
@@ -86,8 +80,8 @@ namespace Carbon.PagedList
                         : 0;
             HasPreviousPage = PageNumber > 1;
             HasNextPage = PageNumber < PageCount;
-            IsFirstPage = PageNumber == 1;
-            IsLastPage = PageNumber >= PageCount;
+            IsFirstPage = isAllDataRequest || PageNumber == 1;
+            IsLastPage = isAllDataRequest || PageNumber >= PageCount;
             FirstItemOnPage = (PageNumber - 1) * PageSize + 1;
             var numberOfLastItemOnPage = FirstItemOnPage + PageSize - 1;
             LastItemOnPage = numberOfLastItemOnPage > TotalItemCount

--- a/Carbon.WebApplication.EntityFrameworkCore/Carbon.WebApplication.EntityFrameworkCore.csproj
+++ b/Carbon.WebApplication.EntityFrameworkCore/Carbon.WebApplication.EntityFrameworkCore.csproj
@@ -2,8 +2,11 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net5.0;netstandard2.1</TargetFrameworks>
-    <Version>2.3.3</Version>
+    <Version>2.3.4</Version>
     <Description>
+		2.3.4
+		Upgrade Carbon.PagedList (Remove pageSize and pageNumber validation check)
+		
 		2.3.3
 		Upgrade Carbon.Domain.EntityFramework version (Added OwnerType.None in ownership filter)
 

--- a/Carbon.WebApplication/Carbon.WebApplication.csproj
+++ b/Carbon.WebApplication/Carbon.WebApplication.csproj
@@ -1,8 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
-		<Version>4.5.2</Version>
+		<Version>4.5.3</Version>
 		<Description>
+			4.5.3
+			- Upgrade Carbon.PagedList (Remove pageSize and pageNumber validation check)
 			4.5.2
 			- Updated Carbon.Common nuget package (Added StringExtensions class with ReplaceTurkishChars and ContainsTurkishIgnoreCase methods)
 			4.5.0
@@ -34,7 +36,6 @@
 			- Cors Wildcards accepted
 			4.1.1
 			- CarbonException messages are take arguments for dynamic exception messages
-
 			4.1.0
 			- Critical bug fixed for Directory separator char to specific platform (Windows,Linux)
 			4.0.0
@@ -43,34 +44,6 @@
 			- Swagger Upgraded
 			- BodyRewind deprecated, thus RoleFilteredDto is now unsupported as it is unnecessary just after repository-level validation introduced
 			- Some Performance Improvements
-
-			3.7.0
-			- Swagger server definition added
-			3.6.0
-			- ConfigureEndpoint is now a virtual class rather than an abstract
-			- HealthCheck partial healthy (degraded) also causes endpoint to generate 5xx http status code
-			3.5.0
-			- ConfigureEndpoint support added when needed
-			3.4.5
-			- Bearer Authenticator can now be passed some events
-			3.4.4
-			- Swager Header tenantId added if not exist
-			3.4.0
-			- GetUserName extension method added
-			3.3.2
-			-Swagger Header(P360SolutonId) Added
-			3.3.1
-			- Swagger RoutePrefix added
-			3.3.0
-			- Cors ExposeHeaders added
-			3.2.0
-			- Fluent Validation crash on dotnet 5 applications fixed
-			- CarbonValidator class moved here from ExceptionHandling Package
-			- Fluent Validation upgraded
-			3.1.0
-			- Tenant Ownership new features and performance improvements
-			3.0.0
-			- Added new error handling mechanism
 		</Description>
 		<OpenApiGenerateDocuments>false</OpenApiGenerateDocuments>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>

--- a/tests/Carbon.PagedList.EntityFrameworkCore.UnitTests/DataShares/QueryableExtensionsDataShare.cs
+++ b/tests/Carbon.PagedList.EntityFrameworkCore.UnitTests/DataShares/QueryableExtensionsDataShare.cs
@@ -18,17 +18,4 @@ namespace Carbon.PagedList.EntityFrameworkCore.UnitTests.DataShares
             yield return new object[] { null, 10, 2 };
         }
     }
-
-    public class InValidToPagedListQueryableExtensions : DataAttribute
-    {
-        public override IEnumerable<object[]> GetData(MethodInfo testMethod)
-        {
-            var context = EFRepositoryFixture.CreateContext();
-            EFRepositoryFixture.CreateData(context, Guid.NewGuid(), Guid.NewGuid());
-
-            //data, pageNumber, pageSize
-            yield return new object[] { context.CarbonContextTestClass, -1, -1 };
-            yield return new object[] { null, -10, -2 };
-        }
-    }
 }

--- a/tests/Carbon.PagedList.EntityFrameworkCore.UnitTests/PagedListExtensionsTest.cs
+++ b/tests/Carbon.PagedList.EntityFrameworkCore.UnitTests/PagedListExtensionsTest.cs
@@ -32,19 +32,5 @@ namespace Carbon.PagedList.EntityFrameworkCore.UnitTests
 
             _testOutputHelper.WriteLine("Test passed!");
         }
-
-        [Theory]
-        [InValidToPagedListQueryableExtensions]
-        public void ToPagedListAsync_Exception_PagedListExtensions(IQueryable<TEntity> entity, int pageNumber, int pageSize)
-        {
-            // Arrange
-            // Act
-            var wrapper = new QueryableExtensionsWrapper<TEntity>();
-            var response = wrapper.ToPagedListAsync(entity, pageNumber, pageSize);
-            // Assert
-            Assert.NotNull(response.Exception);
-
-            _testOutputHelper.WriteLine("Test passed!");
-        }
     }
 }

--- a/tests/Carbon.PagedList.UnitTests/BasePagedListTests.cs
+++ b/tests/Carbon.PagedList.UnitTests/BasePagedListTests.cs
@@ -32,20 +32,6 @@ namespace Carbon.PagedList.UnitTests
         }
 
         [Fact]
-        public void CreateBasePagedList_InvalidPageNumber_ThrowArgumentException()
-        {
-            // Act & Assert
-            Assert.Throws<ArgumentOutOfRangeException>(() => new TestBasePagedList<string>(0, 1, 1));
-        }
-
-        [Fact]
-        public void CreateBasePagedList_InvalidPageSize_ThrowArgumentException()
-        {
-            // Act & Assert
-            Assert.Throws<ArgumentOutOfRangeException>(() => new TestBasePagedList<string>(4, 0, 1));
-        }
-
-        [Fact]
         public void GetEnumerator_GetSuccessfully_ReturnEnumerator()
         {
             // Arrange

--- a/tests/Carbon.PagedList.UnitTests/PagedListTests.cs
+++ b/tests/Carbon.PagedList.UnitTests/PagedListTests.cs
@@ -1,7 +1,6 @@
 ﻿using Xunit;
 using System.Collections.Generic;
 using System.Linq;
-using System;
 
 namespace Carbon.PagedList.UnitTests
 {
@@ -40,21 +39,6 @@ namespace Carbon.PagedList.UnitTests
 
             // Assert
             Assert.IsType<PagedList<string>>(x);
-        }
-
-        [Fact]
-        public void CreatePagedList_InvalidPageSize_ThrowException()
-        {
-            // Act & Assert
-            Assert.Throws<ArgumentOutOfRangeException>(() => new PagedList<string>(dataList.AsQueryable(), 1, 0));
-
-        }
-
-        [Fact]
-        public void CreatePagedList_InvalidPageNumber_ThrowException()
-        {
-            // Act & Assert
-            Assert.Throws<ArgumentOutOfRangeException>(() => new PagedList<string>(dataList.AsQueryable(), 0, 5));
         }
 
         [Fact]

--- a/tests/Carbon.WebApplication.UnitTests/BaseDtoValidatorTests.cs
+++ b/tests/Carbon.WebApplication.UnitTests/BaseDtoValidatorTests.cs
@@ -2,7 +2,6 @@
 using Carbon.PagedList;
 using FluentValidation;
 using Moq;
-using System;
 using Xunit;
 
 namespace Carbon.WebApplication.UnitTests
@@ -36,13 +35,6 @@ namespace Carbon.WebApplication.UnitTests
 
             // Assert
             Assert.IsAssignableFrom<PagedList<IValidationRule>>(x);
-        }
-        [Fact]
-        public void PageableDto_InvalidPageNumberAndPageIndex_ThrowException()
-        {
-            // Act
-            // Assert
-            Assert.Throws<ArgumentOutOfRangeException>(() => Mock.Of<BaseDtoValidator<IPageableDto>>().ToPagedList(0, 300));
         }
     }
 }


### PR DESCRIPTION
- The pageSize and pageNumber validations have been deleted from the constructor method in the PagedList and BasePagedList classes in the Carbon.PagedList package.
- Updated version for packages using the Carbon.PagedList package.
- Removed unit test methods about pageSize and pageNumber count.