### PR TITLE
feat: TREN Search or expression changed to and

### DIFF
--- a/Carbon.Domain.EntityFrameworkCore.Extensions/EFExtensions.cs
+++ b/Carbon.Domain.EntityFrameworkCore.Extensions/EFExtensions.cs
@@ -583,7 +583,7 @@ namespace Carbon.Domain.EntityFrameworkCore
                     }
                     else
                     {
-                        finalExpression = Expression.OrElse(finalExpression, wordContainsExpression);
+                        finalExpression = Expression.AndAlso(finalExpression, wordContainsExpression);
                     }
                 }
             }


### PR DESCRIPTION
Changelog:
- WhereContains method's searchByWords property business changed
  - The operation of the "searchByWords" variable has been modified so that all searched words are present at the sametime in each record.