### PR TITLE
feat: WhereContains method's searchByWords property business changed

### DIFF
--- a/Carbon.Domain.EntityFrameworkCore.Extensions/Carbon.Domain.EntityFrameworkCore.csproj
+++ b/Carbon.Domain.EntityFrameworkCore.Extensions/Carbon.Domain.EntityFrameworkCore.csproj
@@ -2,20 +2,23 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>net6.0;net5.0;netstandard2.1</TargetFrameworks>
-		<Version>3.1.6</Version>
+		<Version>3.1.7</Version>
 		<Description>
+			- 3.1.7
+			* WhereContains or extension change to and
+
 			- 3.1.6
 			* WhereContains extension method bug resolved
-			
+
 			- 3.1.5
 			* Upgrade Carbon.PagedList (Remove pageSize and pageNumber validation check)
-			
+
 			- 3.1.3
 			* Added new extension method to EFExtensions (ToPagedListEntityFilteredWithSolution, ToPagedListEntityAsync, WhereContains)
-			
+
 			- 3.1.2
 			* Refactor ownership filtering logic; include 'OwnerType.None' in conditions for more comprehensive permission assessment.
-			
+
 			- 3.1.1
 			* Fixed EFExtensions FirstOrDefaultEntity methods. Null check condition is added for the Relation object
 


### PR DESCRIPTION
- WhereContains method's searchByWords property business changed
   - The operation of the "searchByWords" variable has been modified so that all searched words are present at the sametime in each record.