### PR TITLE
Carbon exception message override improvements.

### DIFF
--- a/Carbon.ExceptionHandling/Carbon.ExceptionHandling.Abstractions.csproj
+++ b/Carbon.ExceptionHandling/Carbon.ExceptionHandling.Abstractions.csproj
@@ -2,8 +2,10 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <Version>1.3.0</Version>
+    <Version>1.3.1</Version>
     <Description>
+		1.3.1
+		- OverrideExceptionDetail is added
 		1.3.0
 		- UnauthorizedOperationException is added
 		1.2.2

--- a/Carbon.ExceptionHandling/CarbonException.cs
+++ b/Carbon.ExceptionHandling/CarbonException.cs
@@ -23,6 +23,8 @@ namespace Carbon.ExceptionHandling.Abstractions
         /// </summary>
         public object[] Arguments { get; set; }
 
+        public bool OverrideExceptionDetail { get; set; } = true;
+
         /// <summary>
         /// CarbonException with only error code 5000.
         /// </summary>

--- a/Carbon.WebApplication/Carbon.WebApplication.csproj
+++ b/Carbon.WebApplication/Carbon.WebApplication.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
-		<Version>4.5.4</Version>
+		<Version>4.5.6</Version>
 		<Description>
-			4.5.4
+			4.5.6
+			- Added a property named overrideMessageAndCode to the CarbonException class. The default value of this property is set to true. In the constructor of CarbonException, check this property to determine whether the message and code are overridden or not.
 			- Update IPageableDto validator for assign PageSize 0. When PageSize 0 the datas returns without pagination with development in version 4.5.3.
 			4.5.3
 			- Upgrade Carbon.PagedList (Remove pageSize and pageNumber validation check)

--- a/Carbon.WebApplication/HttpGlobalExceptionFilter.cs
+++ b/Carbon.WebApplication/HttpGlobalExceptionFilter.cs
@@ -81,7 +81,7 @@ namespace Carbon.WebApplication
 
             if (context.Exception is CarbonException exception)
             {
-                if (!string.IsNullOrEmpty(_errorHandling))
+                if (!string.IsNullOrEmpty(_errorHandling) && exception.OverrideExceptionDetail)
                 {
                     var exceptionMessage = GetErrorMessage(exception.ErrorCode, exception.Arguments, context.HttpContext.Request).Result;
 


### PR DESCRIPTION
Added a property named overrideMessageAndCode to the CarbonException class. The default value of this property is set to true. In the constructor of CarbonException, check this property to determine whether the message and code are overridden or not.