### PR TITLE
Fixed: Elastic search health check gives 5000 even if it's degraded or one unhealth nodes wihin cluster. Now it looks for cluster status

### DIFF
--- a/Carbon.ElasticSearch/Carbon.ElasticSearch.csproj
+++ b/Carbon.ElasticSearch/Carbon.ElasticSearch.csproj
@@ -3,35 +3,37 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <ProjectGuid>{7AEAD788-E78D-4825-9761-AEB2570DE3E0}</ProjectGuid>
-    <Version>3.7.0</Version>
+    <Version>3.7.1</Version>
     <Description>
-	    3.7.0
-	    - DeleteAllAsync method is added IElasticRepository to clear all index data by tenantId
-		3.6.1
-		- Carbon.Common Bulk index operations had better get IEnumerable as parameter
-		3.6.0
-		- Carbon.Common Bulk index operations added (AddBulkAndReturn and AddBulkAndReturnAsync)
-		3.5.2
-		- Carbon.Common updated and IQueryable OrderBy extension method bug fixed
-		3.5.1
-		- Carbon.Common updated and nested ordering achieved
-		3.5.0
-		- Readonly Elastic repository implemented.
-		- Paging functions added to BaseElasticRepositories.
+      3.7.1
+      - Health check fixed
+      3.7.0
+      - DeleteAllAsync method is added IElasticRepository to clear all index data by tenantId
+      3.6.1
+      - Carbon.Common Bulk index operations had better get IEnumerable as parameter
+      3.6.0
+      - Carbon.Common Bulk index operations added (AddBulkAndReturn and AddBulkAndReturnAsync)
+      3.5.2
+      - Carbon.Common updated and IQueryable OrderBy extension method bug fixed
+      3.5.1
+      - Carbon.Common updated and nested ordering achieved
+      3.5.0
+      - Readonly Elastic repository implemented.
+      - Paging functions added to BaseElasticRepositories.
 
-		3.2.0
-		- Refresh parameter added to create, update and delete methods
-		3.1.3
-		Added Health Check
+      3.2.0
+      - Refresh parameter added to create, update and delete methods
+      3.1.3
+      Added Health Check
 
-		** ElasticSearch 7 Library
-		** For older versions, please use Platform360.ElasticSearch(Deprecated) from Cosmos Nuget Repo
+      ** ElasticSearch 7 Library
+      ** For older versions, please use Platform360.ElasticSearch(Deprecated) from Cosmos Nuget Repo
 
-		3.1.2
+      3.1.2
 
-		- FindAsync with Size added
-		- New Configuration added for force refresh on writing operations
-		-ElasticSearch.NET &amp; Nest Libraries Updated to 7.11.1
+      - FindAsync with Size added
+      - New Configuration added for force refresh on writing operations
+      -ElasticSearch.NET &amp; Nest Libraries Updated to 7.11.1
 		-Sort feature added for FilterAsync.
 	</Description>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>


### PR DESCRIPTION
Fixed: Elastic search health check gives 5000 even if it's degraded or one unhealth nodes wihin cluster. Now it looks for cluster status