### PR TITLE
fix: refactor OwnershipFilter to use async/await for external service calls

### DIFF
--- a/Carbon.WebApplication/Carbon.WebApplication.csproj
+++ b/Carbon.WebApplication/Carbon.WebApplication.csproj
@@ -3,6 +3,8 @@
 		<TargetFrameworks>net8.0;net6.0</TargetFrameworks>
 		<Version>4.6.5</Version>
 		<Description>
+			4.6.6
+			- Refactored OwnershipFilter to use async/await for external service calls; improved Authorization header handling and permission checks.
 			4.6.5
 			- Microsoft.Extensions.Logging package added
 			4.6.4

--- a/Carbon.WebApplication/Carbon.WebApplication.csproj
+++ b/Carbon.WebApplication/Carbon.WebApplication.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFrameworks>net8.0;net6.0</TargetFrameworks>
-		<Version>4.6.5</Version>
+		<Version>4.6.6</Version>
 		<Description>
 			4.6.6
 			- Refactored OwnershipFilter to use async/await for external service calls; improved Authorization header handling and permission checks.

--- a/Carbon.WebApplication/TenantManagementHandler/ControllerAttributes/OwnershipFilter.cs
+++ b/Carbon.WebApplication/TenantManagementHandler/ControllerAttributes/OwnershipFilter.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Primitives;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace Carbon.WebApplication.TenantManagementHandler.ControllerAttributes
 {
@@ -44,64 +45,76 @@ namespace Carbon.WebApplication.TenantManagementHandler.ControllerAttributes
             _ownershipType = ownershipType;
         }
 
-        public override void OnActionExecuting(ActionExecutingContext context)
+        public override async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
         {
-            var _externalService = context.HttpContext.RequestServices.GetService<IExternalService>();
-            //var solutions = context.GetSolutionFilter();
-            var userId = ((CarbonController)context.Controller).User.GetUserId();
-            var tenantId = ((CarbonController)context.Controller).User.GetTenantId();
-            var organizationId = ((CarbonController)context.Controller).User.GetOrganizationId();
-            var isGodUser = ((CarbonController)context.Controller).User.CheckIfGodUser();
-            context.HttpContext.Request.Headers.TryGetValue("Authorization", out StringValues daToken);
+            var httpContext = context.HttpContext;
+            var controller = (CarbonController)context.Controller;
+            var user = controller.User;
 
-            List<PermissionDetailedDto> filterOwnershipPermissionList;
+            var isGodUser = user.CheckIfGodUser();
 
             if (_ownershipType == OwnershipType.Goduser && !isGodUser)
                 throw new ForbiddenOperationException(CarbonExceptionMessages.OnlyGodUserOperation);
 
             if (isGodUser)
+            {
+                await next();
                 return;
+            }
 
-            //if (solutions == null || !solutions.Any())
-            //    throw new ForbiddenOperationException(CarbonExceptionMessages.SolutionHeaderMustBeSet);
+            var _externalService = httpContext.RequestServices.GetService<IExternalService>();
+            var userId = user.GetUserId();
+            var tenantId = user.GetTenantId();
+            var organizationId = user.GetOrganizationId();
 
+            httpContext.Request.Headers.TryGetValue("Authorization", out StringValues authHeader);
+            var tokenParts = authHeader.ToString().Split(' ');
+            var token = tokenParts.Length > 1 ? tokenParts[1] : null;
 
-            filterOwnershipPermissionList = _externalService.ExecuteInPolicyApi_GetRoles(new PermissionDetailedFilterDto() 
-                { 
-                    TenantId = tenantId, 
-                    UserPolicyId = organizationId, 
-                    UserId = userId, 
-                    SolutionId = null, 
-                    PermissionNames = new List<string>() { _role } 
-                }, daToken.ToString().Split(' ')[1]).Result;
+            if (string.IsNullOrEmpty(token))
+            {
+                httpContext.Response.StatusCode = 401;
+                context.Result = new JsonResult(new { response = "Unauthorized", message = "Authorization header is invalid or missing token." });
+                return;
+            }
+
+            List<PermissionDetailedDto> filterOwnershipPermissionList;
+
+            filterOwnershipPermissionList = await _externalService.ExecuteInPolicyApi_GetRoles(
+                new PermissionDetailedFilterDto()
+                {
+                    TenantId = tenantId,
+                    UserPolicyId = organizationId,
+                    UserId = userId,
+                    SolutionId = null,
+                    PermissionNames = new List<string>() { _role }
+                }, token);
 
             RoleExtensions.SetPermissions(filterOwnershipPermissionList);
 
             if (_ownershipType == OwnershipType.Admin)
-                if (filterOwnershipPermissionList == null || !(filterOwnershipPermissionList.Where(k => k.OriginatedRoleType <= 2).Any()))
-                {
+            {
+                if (filterOwnershipPermissionList == null || !filterOwnershipPermissionList.Any(k => k.OriginatedRoleType <= 2))
                     throw new ForbiddenOperationException(CarbonExceptionMessages.OnlyAdminUserOperation);
-                }
+            }
 
             if (_ownershipType == OwnershipType.Superadmin)
-                if (filterOwnershipPermissionList == null || !(filterOwnershipPermissionList.Where(k => k.OriginatedRoleType == 1).Any()))
-                {
+            {
+                if (filterOwnershipPermissionList == null || !filterOwnershipPermissionList.Any(k => k.OriginatedRoleType == 1))
                     throw new ForbiddenOperationException(CarbonExceptionMessages.OnlySuperAdminUserOperation);
-                }
+            }
 
             if (filterOwnershipPermissionList != null && filterOwnershipPermissionList.Any())
             {
-                var relatedController = ((IOwnershipFilteredController)context.Controller);
+                var relatedController = (IOwnershipFilteredController)context.Controller;
                 relatedController.OwnershipFilteredServices.ForEach(k => k.SetFilter(filterOwnershipPermissionList));
+                await next();
             }
             else
             {
-                context.HttpContext.Response.StatusCode = 403;
+                httpContext.Response.StatusCode = 403;
                 context.Result = new JsonResult(new { response = "No_Permission", message = _role + " permission not found!" });
             }
-
         }
-
-
     }
 }


### PR DESCRIPTION
This PR updates the OwnershipFilter class to replace the synchronous OnActionExecuting method with an asynchronous OnActionExecutionAsync implementation. The goal is to improve scalability by making external API calls non-blocking and align with modern ASP.NET Core best practices.

- Replaced OnActionExecuting with OnActionExecutionAsync.
- Updated external service call (ExecuteInPolicyApi_GetRoles) to be awaited asynchronously.
- Added safe parsing of the Authorization header to prevent potential IndexOutOfRangeException.
- Added handling for missing or invalid tokens (returns 401 with JSON response).