### PR TITLE
feat: carbon.audit added

### DIFF
--- a/Carbon Framework.sln
+++ b/Carbon Framework.sln
@@ -134,6 +134,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "api_docs", "api_docs", "{B3
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Carbon.Serilog", "Carbon.Serilog\Carbon.Serilog.csproj", "{5D0A11FD-38C0-474D-955A-63B3FD53AAAD}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Carbon.Audit", "Carbon.Audit\Carbon.Audit.csproj", "{4A34E03F-A25C-426F-A5D0-E9B57933D13F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -308,6 +310,10 @@ Global
 		{5D0A11FD-38C0-474D-955A-63B3FD53AAAD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5D0A11FD-38C0-474D-955A-63B3FD53AAAD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5D0A11FD-38C0-474D-955A-63B3FD53AAAD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4A34E03F-A25C-426F-A5D0-E9B57933D13F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4A34E03F-A25C-426F-A5D0-E9B57933D13F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4A34E03F-A25C-426F-A5D0-E9B57933D13F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4A34E03F-A25C-426F-A5D0-E9B57933D13F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Carbon.Audit/Carbon.Audit.csproj
+++ b/Carbon.Audit/Carbon.Audit.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <Version>1.0.0</Version>
+    <Description>
+      1.0.0
+      - Initial release. RequestContextMiddleware, AuditInterceptor and audit constants added.
+    </Description>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.11" />
+    <PackageReference Include="MassTransit" Version="7.3.1" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.25" />
+    <PackageReference Include="MassTransit" Version="7.3.1" />
+  </ItemGroup>
+
+</Project>

--- a/Carbon.Audit/CarbonAuditSettings.cs
+++ b/Carbon.Audit/CarbonAuditSettings.cs
@@ -1,0 +1,21 @@
+namespace Carbon.Audit;
+
+/// <summary>
+/// Configuration settings for Carbon.Audit.
+/// Bind this from the "CarbonAudit" section of your appsettings.json.
+/// <code>
+/// "CarbonAudit": {
+///   "Enabled": true
+/// }
+/// </code>
+/// </summary>
+public class CarbonAuditSettings
+{
+    /// <summary>
+    /// Gets or sets whether Carbon.Audit is enabled.
+    /// When <c>true</c>, the audit interceptor and middleware are registered automatically.
+    /// Default is <c>false</c>.
+    /// </summary>
+    public bool Enabled { get; set; }
+}
+

--- a/Carbon.Audit/Contracts/AuditAction.cs
+++ b/Carbon.Audit/Contracts/AuditAction.cs
@@ -1,0 +1,8 @@
+namespace Carbon.Audit.Contracts;
+
+public enum AuditAction
+{
+    Created = 0,
+    Updated = 1,
+    Deleted = 2
+}

--- a/Carbon.Audit/Contracts/AuditEvent.cs
+++ b/Carbon.Audit/Contracts/AuditEvent.cs
@@ -1,0 +1,33 @@
+using System.Text.Json.Serialization;
+
+namespace Carbon.Audit.Contracts;
+
+public sealed class AuditEvent
+{
+    public Guid Id { get; set; }
+    
+    public DateTime Timestamp { get; set; }
+
+    public string? UserId { get; set; }
+    public string? UserName { get; set; }
+    public string? UserEmail { get; set; }
+    public string? IpAddress { get; set; }
+    public string? SessionId { get; set; }
+
+    [JsonPropertyName("clientSource")]
+    public ClientSource? ClientSource { get; set; }
+    
+    public string? CorrelationId { get; set; }
+
+    public string? Service { get; set; }
+    public string? EntityType { get; set; }
+    public string? EntityId { get; set; }
+    public string? EntityName { get; set; }
+
+    public AuditAction Action { get; set; }
+    
+    public object? Before { get; set; }
+    public object? After { get; set; }
+
+    public List<FieldChange> Changes { get; set; } = new();
+}

--- a/Carbon.Audit/Contracts/AuditEvent.cs
+++ b/Carbon.Audit/Contracts/AuditEvent.cs
@@ -25,6 +25,8 @@ public sealed class AuditEvent
     public string? EntityName { get; set; }
 
     public AuditAction Action { get; set; }
+    public string? Endpoint { get; set; } 
+    public string? Payload { get; set; }
     
     public object? Before { get; set; }
     public object? After { get; set; }

--- a/Carbon.Audit/Contracts/AuditIgnoreAttribute.cs
+++ b/Carbon.Audit/Contracts/AuditIgnoreAttribute.cs
@@ -1,0 +1,7 @@
+namespace Carbon.Audit.Contracts;
+
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false, Inherited = true)]
+public sealed class AuditIgnoreAttribute : Attribute
+{
+    
+}

--- a/Carbon.Audit/Contracts/AuditableAttribute.cs
+++ b/Carbon.Audit/Contracts/AuditableAttribute.cs
@@ -1,0 +1,7 @@
+namespace Carbon.Audit.Contracts;
+
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method | AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
+public sealed class AuditableAttribute : Attribute
+{
+    
+}

--- a/Carbon.Audit/Contracts/ClientSource.cs
+++ b/Carbon.Audit/Contracts/ClientSource.cs
@@ -1,0 +1,10 @@
+namespace Carbon.Audit.Contracts;
+
+public enum ClientSource
+{
+    Platform = 0,
+    HMI = 1,
+    BackgroundJob = 2,
+    Migration = 3,
+    SystemJob = 4
+}

--- a/Carbon.Audit/Contracts/FieldChange.cs
+++ b/Carbon.Audit/Contracts/FieldChange.cs
@@ -1,0 +1,8 @@
+namespace Carbon.Audit.Contracts;
+
+public sealed class FieldChange
+{
+    public string? Field { get; set; }
+    public object? Before { get; set; }
+    public object? After { get; set; }
+}

--- a/Carbon.Audit/Producer/AuditEntryPending.cs
+++ b/Carbon.Audit/Producer/AuditEntryPending.cs
@@ -1,0 +1,10 @@
+using Carbon.Audit.Contracts;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+
+namespace Carbon.Audit.Producer;
+
+internal sealed class AuditEntryPending
+{
+    public EntityEntry Entry { get; set; } = null!;
+    public AuditEvent Event { get; set; } = null!;
+}

--- a/Carbon.Audit/Producer/AuditInterceptor.cs
+++ b/Carbon.Audit/Producer/AuditInterceptor.cs
@@ -14,6 +14,8 @@ public sealed class AuditInterceptor : SaveChangesInterceptor
     private readonly IAuditEventPublisher _publisher;
     private readonly ILogger<AuditInterceptor> _logger;
 
+    private List<AuditEntryPending>? _pendingAudits;
+
     public AuditInterceptor(
         RequestContext ctx,
         IAuditEventPublisher publisher,
@@ -23,39 +25,83 @@ public sealed class AuditInterceptor : SaveChangesInterceptor
         _publisher = publisher;
         _logger = logger;
     }
-
-    public override async ValueTask<InterceptionResult<int>> SavingChangesAsync(
+    
+    public override ValueTask<InterceptionResult<int>> SavingChangesAsync(
         DbContextEventData eventData,
         InterceptionResult<int> result,
-        CancellationToken ct = default)
+        CancellationToken cancellationToken)
     {
         if (_requestContext.IsHmiRequest)
-            return await base.SavingChangesAsync(eventData, result, ct);
+            return base.SavingChangesAsync(eventData, result, cancellationToken); 
 
         try
         {
             if (eventData.Context is not { } db)
-                return await base.SavingChangesAsync(eventData, result, ct);
-
-            var events = BuildAuditEvents(db.ChangeTracker.Entries());
-
-            if (events.Count > 0)
-                _ = _publisher.PublishBatchAsync(events); // fire-and-forget
+                return base.SavingChangesAsync(eventData, result, cancellationToken); 
+            
+            _pendingAudits = BuildPendingAudits(db.ChangeTracker.Entries());
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "[AUDIT] Failed to build audit events");
+            _logger.LogError(ex, "[AUDIT] Failed to build pending audit events");
         }
 
-        return await base.SavingChangesAsync(eventData, result, ct);
+        return base.SavingChangesAsync(eventData, result, cancellationToken); 
     }
+    
+    public override async ValueTask<int> SavedChangesAsync(
+        SaveChangesCompletedEventData eventData,
+        int result,
+        CancellationToken cancellationToken)
+    {
+        if (_pendingAudits != null && _pendingAudits.Count > 0)
+        {
+            try
+            {
+                var eventsToPublish = new List<AuditEvent>();
 
-    private List<AuditEvent> BuildAuditEvents(IEnumerable<EntityEntry> entries)
+                foreach (var pending in _pendingAudits)
+                {
+                    var evt = pending.Event;
+
+                    if (evt.Action == AuditAction.Created)
+                    {
+                        evt.EntityId = GetPrimaryKey(pending.Entry);
+                        evt.After = GetSnapshot(pending.Entry, original: false);
+                    }
+
+                    eventsToPublish.Add(evt);
+                }
+                
+                await _publisher.PublishBatchAsync(eventsToPublish);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "[AUDIT] Failed to publish audit events after save");
+            }
+            finally
+            {
+                _pendingAudits.Clear();
+            }
+        }
+
+        return await base.SavedChangesAsync(eventData, result, cancellationToken);
+    }
+    
+    public override Task SaveChangesFailedAsync(
+        DbContextErrorEventData eventData,
+        CancellationToken cancellationToken)
+    {
+        _pendingAudits?.Clear();
+        return base.SaveChangesFailedAsync(eventData, cancellationToken);
+    }
+    
+    private List<AuditEntryPending> BuildPendingAudits(IEnumerable<EntityEntry> entries)
     {
         return entries
             .Where(e => e.State is EntityState.Added or EntityState.Modified or EntityState.Deleted)
             .Where(e => e.Entity.GetType().IsDefined(typeof(AuditableAttribute), inherit: true))
-            .Select(BuildEvent)
+            .Select(e => new AuditEntryPending { Entry = e, Event = BuildEvent(e) }) 
             .ToList();
     }
 
@@ -85,7 +131,9 @@ public sealed class AuditInterceptor : SaveChangesInterceptor
             
             Action = action,
             Before = action != AuditAction.Created ? GetSnapshot(entry, original: true) : null,
-            After = action != AuditAction.Deleted ? GetSnapshot(entry, original: false) : null,
+            
+            After = action == AuditAction.Updated ? GetSnapshot(entry, original: false) : null,
+            
             Changes = action == AuditAction.Updated ? GetFieldDiffs(entry) : new(),
         };
     }
@@ -119,8 +167,8 @@ public sealed class AuditInterceptor : SaveChangesInterceptor
             .Select(p => new FieldChange
             {
                 Field = p.Metadata.Name,
-                Before = p.OriginalValue?.ToString(),
-                After = p.CurrentValue?.ToString()
+                Before = p.OriginalValue, 
+                After = p.CurrentValue
             })
             .ToList();
     }

--- a/Carbon.Audit/Producer/AuditInterceptor.cs
+++ b/Carbon.Audit/Producer/AuditInterceptor.cs
@@ -1,0 +1,153 @@
+using System.Reflection;
+using Carbon.Audit.Contracts;
+using Carbon.Audit.Producer.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace Carbon.Audit.Producer;
+
+public sealed class AuditInterceptor : SaveChangesInterceptor
+{
+    private readonly RequestContext _requestContext;
+    private readonly IAuditEventPublisher _publisher;
+    private readonly ILogger<AuditInterceptor> _logger;
+
+    public AuditInterceptor(
+        RequestContext ctx,
+        IAuditEventPublisher publisher,
+        ILogger<AuditInterceptor> logger)
+    {
+        _requestContext = ctx;
+        _publisher = publisher;
+        _logger = logger;
+    }
+
+    public override async ValueTask<InterceptionResult<int>> SavingChangesAsync(
+        DbContextEventData eventData,
+        InterceptionResult<int> result,
+        CancellationToken ct = default)
+    {
+        if (_requestContext.IsHmiRequest)
+            return await base.SavingChangesAsync(eventData, result, ct);
+
+        try
+        {
+            if (eventData.Context is not { } db)
+                return await base.SavingChangesAsync(eventData, result, ct);
+
+            var events = BuildAuditEvents(db.ChangeTracker.Entries());
+
+            if (events.Count > 0)
+                _ = _publisher.PublishBatchAsync(events); // fire-and-forget
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "[AUDIT] Failed to build audit events");
+        }
+
+        return await base.SavingChangesAsync(eventData, result, ct);
+    }
+
+    private List<AuditEvent> BuildAuditEvents(IEnumerable<EntityEntry> entries)
+    {
+        return entries
+            .Where(e => e.State is EntityState.Added or EntityState.Modified or EntityState.Deleted)
+            .Where(e => e.Entity.GetType().IsDefined(typeof(AuditableAttribute), inherit: true))
+            .Select(BuildEvent)
+            .ToList();
+    }
+
+    private AuditEvent BuildEvent(EntityEntry entry)
+    {
+        var entityType = entry.Entity.GetType();
+        var action = MapAction(entry.State);
+
+        return new AuditEvent
+        {
+            Id = Guid.NewGuid(),
+            Timestamp = DateTime.UtcNow,
+            UserId = _requestContext.UserId,
+            UserName = _requestContext.UserName,
+            UserEmail = _requestContext.UserEmail,
+            IpAddress = _requestContext.IpAddress,
+            SessionId = _requestContext.SessionId,
+            ClientSource = _requestContext.Source,
+            CorrelationId = _requestContext.CorrelationId,
+            
+            Service = Assembly.GetEntryAssembly()?.GetName().Name,
+            EntityType = entityType.Name,
+            EntityId = GetPrimaryKey(entry),
+            EntityName = GetEntityName(entry),
+            
+            Action = action,
+            Before = action != AuditAction.Created ? GetSnapshot(entry, original: true) : null,
+            After = action != AuditAction.Deleted ? GetSnapshot(entry, original: false) : null,
+            Changes = action == AuditAction.Updated ? GetFieldDiffs(entry) : new(),
+        };
+    }
+    
+    private static HashSet<string> GetIgnoredProperties(EntityEntry entry)
+    {
+        return entry.Entity.GetType().GetProperties()
+            .Where(p => p.IsDefined(typeof(AuditIgnoreAttribute), true))
+            .Select(p => p.Name)
+            .ToHashSet(StringComparer.Ordinal);
+    }
+
+    private static Dictionary<string, object?> GetSnapshot(EntityEntry entry, bool original)
+    {
+        var ignoredProps = GetIgnoredProperties(entry);
+
+        return entry.Properties
+            .Where(p => !ignoredProps.Contains(p.Metadata.Name))
+            .ToDictionary(
+                p => p.Metadata.Name,
+                p => original ? p.OriginalValue : p.CurrentValue);
+    }
+
+    private static List<FieldChange> GetFieldDiffs(EntityEntry entry)
+    {
+        var ignoredProps = GetIgnoredProperties(entry);
+
+        return entry.Properties
+            .Where(p => p.IsModified)
+            .Where(p => !ignoredProps.Contains(p.Metadata.Name))
+            .Select(p => new FieldChange
+            {
+                Field = p.Metadata.Name,
+                Before = p.OriginalValue?.ToString(),
+                After = p.CurrentValue?.ToString()
+            })
+            .ToList();
+    }
+
+    private static string GetPrimaryKey(EntityEntry entry)
+    {
+        var key = entry.Metadata.FindPrimaryKey();
+        if (key == null) return string.Empty;
+        
+        var values = key.Properties.Select(p => entry.Property(p.Name).CurrentValue ?? entry.Property(p.Name).OriginalValue);
+        return string.Join("_", values);
+    }
+
+    private static string GetEntityName(EntityEntry entry)
+    {
+        foreach (var prop in new[] { "Name", "Title", "Code", "Number" })
+        {
+            var p = entry.Properties.FirstOrDefault(x => x.Metadata.Name == prop);
+            if (p?.CurrentValue is string s && !string.IsNullOrEmpty(s)) return s;
+        }
+
+        return GetPrimaryKey(entry);
+    }
+
+    private static AuditAction MapAction(EntityState state) => state switch
+    {
+        EntityState.Added => AuditAction.Created,
+        EntityState.Modified => AuditAction.Updated,
+        EntityState.Deleted => AuditAction.Deleted,
+        _ => throw new ArgumentOutOfRangeException(nameof(state))
+    };
+}

--- a/Carbon.Audit/Producer/AuditInterceptor.cs
+++ b/Carbon.Audit/Producer/AuditInterceptor.cs
@@ -75,6 +75,8 @@ public sealed class AuditInterceptor : SaveChangesInterceptor
             SessionId = _requestContext.SessionId,
             ClientSource = _requestContext.Source,
             CorrelationId = _requestContext.CorrelationId,
+            Endpoint = _requestContext.Endpoint,
+            Payload = _requestContext.Payload,
             
             Service = Assembly.GetEntryAssembly()?.GetName().Name,
             EntityType = entityType.Name,

--- a/Carbon.Audit/Producer/Http/RequestContext.cs
+++ b/Carbon.Audit/Producer/Http/RequestContext.cs
@@ -13,6 +13,8 @@ public sealed class RequestContext
     
     public ClientSource Source { get; set; } = ClientSource.Platform;
     public string? CorrelationId { get; set; }
+    public string? Endpoint { get; set; }
+    public string? Payload { get; set; }
 
     public bool IsHmiRequest => Source == ClientSource.HMI;
 }

--- a/Carbon.Audit/Producer/Http/RequestContext.cs
+++ b/Carbon.Audit/Producer/Http/RequestContext.cs
@@ -1,0 +1,18 @@
+using Carbon.Audit.Contracts;
+
+namespace Carbon.Audit.Producer.Http;
+
+public sealed class RequestContext
+{
+    public string UserId { get; set; } = "system";
+    public string UserName { get; set; } = "System";
+    public string UserEmail { get; set; } = string.Empty;
+    public string SessionId { get; set; } = string.Empty;
+    
+    public string IpAddress { get; set; } = string.Empty;
+    
+    public ClientSource Source { get; set; } = ClientSource.Platform;
+    public string? CorrelationId { get; set; }
+
+    public bool IsHmiRequest => Source == ClientSource.HMI;
+}

--- a/Carbon.Audit/Producer/IAuditEventPublisher.cs
+++ b/Carbon.Audit/Producer/IAuditEventPublisher.cs
@@ -1,0 +1,9 @@
+using Carbon.Audit.Contracts;
+
+namespace Carbon.Audit.Producer;
+
+public interface IAuditEventPublisher
+{
+    Task PublishAsync(AuditEvent evt);
+    Task PublishBatchAsync(IEnumerable<AuditEvent> events);
+}

--- a/Carbon.Audit/Producer/RabbitMqAuditEventPublisher.cs
+++ b/Carbon.Audit/Producer/RabbitMqAuditEventPublisher.cs
@@ -1,0 +1,43 @@
+using System.Text.Json;
+using Carbon.Audit.Contracts;
+using MassTransit;
+using Microsoft.Extensions.Logging;
+
+namespace Carbon.Audit.Producer;
+
+public sealed class RabbitMqAuditEventPublisher : IAuditEventPublisher
+{
+    private readonly IPublishEndpoint _bus;
+    private readonly ILogger<RabbitMqAuditEventPublisher> _logger;
+
+    public RabbitMqAuditEventPublisher(
+        IPublishEndpoint bus,
+        ILogger<RabbitMqAuditEventPublisher> logger)
+    {
+        _bus = bus;
+        _logger = logger;
+    }
+
+    public Task PublishAsync(AuditEvent evt)
+        => PublishBatchAsync(new[] { evt });
+
+    public Task PublishBatchAsync(IEnumerable<AuditEvent> events)
+    {
+        var list = events?.ToList() ?? new List<AuditEvent>();
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                foreach (var evt in list)
+                    await _bus.Publish(evt);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "[AUDIT_FALLBACK] {Events}", JsonSerializer.Serialize(list));
+            }
+        });
+
+        return Task.CompletedTask;
+    }
+}

--- a/Carbon.Audit/Producer/RabbitMqAuditEventPublisher.cs
+++ b/Carbon.Audit/Producer/RabbitMqAuditEventPublisher.cs
@@ -21,23 +21,18 @@ public sealed class RabbitMqAuditEventPublisher : IAuditEventPublisher
     public Task PublishAsync(AuditEvent evt)
         => PublishBatchAsync(new[] { evt });
 
-    public Task PublishBatchAsync(IEnumerable<AuditEvent> events)
+    public async Task PublishBatchAsync(IEnumerable<AuditEvent> events)
     {
         var list = events?.ToList() ?? new List<AuditEvent>();
 
-        _ = Task.Run(async () =>
+        try
         {
-            try
-            {
-                foreach (var evt in list)
-                    await _bus.Publish(evt);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "[AUDIT_FALLBACK] {Events}", JsonSerializer.Serialize(list));
-            }
-        });
-
-        return Task.CompletedTask;
+            foreach (var evt in list)
+                await _bus.Publish(evt);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "[AUDIT_FALLBACK] {Events}", JsonSerializer.Serialize(list));
+        }
     }
 }

--- a/Carbon.Audit/Producer/RequestContextMiddleware.cs
+++ b/Carbon.Audit/Producer/RequestContextMiddleware.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Security.Claims;
 using Carbon.Audit.Contracts;
 using Carbon.Audit.Producer.Http;
@@ -61,7 +62,7 @@ public sealed class RequestContextMiddleware
         var remoteIp = http.Connection.RemoteIpAddress;
         string? ip = remoteIp?.ToString();
         
-        if (remoteIp == null || IpAddress.IsLoopback(remoteIp))
+        if (remoteIp == null || IPAddress.IsLoopback(remoteIp))
         {
             var forwardedHeader = http.Request.Headers["X-Forwarded-For"].FirstOrDefault();
             if (!string.IsNullOrWhiteSpace(forwardedHeader))

--- a/Carbon.Audit/Producer/RequestContextMiddleware.cs
+++ b/Carbon.Audit/Producer/RequestContextMiddleware.cs
@@ -2,6 +2,7 @@ using System.Security.Claims;
 using Carbon.Audit.Contracts;
 using Carbon.Audit.Producer.Http;
 using Microsoft.AspNetCore.Http;
+using System.Text;
 
 namespace Carbon.Audit.Producer;
 
@@ -16,6 +17,24 @@ public sealed class RequestContextMiddleware
 
     public async Task InvokeAsync(HttpContext http, RequestContext ctx)
     {
+        var endpoint = http.GetEndpoint();
+        ctx.Endpoint = endpoint?.DisplayName ?? http.Request.Path;
+        
+        var method = http.Request.Method.ToUpperInvariant();
+        
+        if (method is "POST" or "PUT" or "DELETE")
+        {
+            http.Request.EnableBuffering(); 
+            
+            using (var reader = new StreamReader(http.Request.Body, Encoding.UTF8, true, 1024, leaveOpen: true))
+            {
+                var body = await reader.ReadToEndAsync();
+                ctx.Payload = body;
+                
+                http.Request.Body.Position = 0;
+            }
+        }
+        
         var user = http.User;
 
         ctx.UserId =
@@ -38,8 +57,20 @@ public sealed class RequestContextMiddleware
             ClaimValue(user, "sid") ??
             ClaimValue(user, "jti") ??  
             string.Empty;
-
-        ctx.IpAddress = http.Connection.RemoteIpAddress?.ToString() ?? string.Empty;
+        
+        var remoteIp = http.Connection.RemoteIpAddress;
+        string? ip = remoteIp?.ToString();
+        
+        if (remoteIp == null || IPAddress.IsLoopback(remoteIp))
+        {
+            var forwardedHeader = http.Request.Headers["X-Forwarded-For"].FirstOrDefault();
+            if (!string.IsNullOrWhiteSpace(forwardedHeader))
+            {
+                ip = forwardedHeader.Split(',').FirstOrDefault()?.Trim();
+            }
+        }
+        
+        ctx.IpAddress = ip ?? string.Empty;
 
         var clientType = http.Request.Headers["X-Client-Type"].FirstOrDefault();
         ctx.Source = clientType?.Equals("HMI", StringComparison.OrdinalIgnoreCase) == true

--- a/Carbon.Audit/Producer/RequestContextMiddleware.cs
+++ b/Carbon.Audit/Producer/RequestContextMiddleware.cs
@@ -61,7 +61,7 @@ public sealed class RequestContextMiddleware
         var remoteIp = http.Connection.RemoteIpAddress;
         string? ip = remoteIp?.ToString();
         
-        if (remoteIp == null || IPAddress.IsLoopback(remoteIp))
+        if (remoteIp == null || IpAddress.IsLoopback(remoteIp))
         {
             var forwardedHeader = http.Request.Headers["X-Forwarded-For"].FirstOrDefault();
             if (!string.IsNullOrWhiteSpace(forwardedHeader))

--- a/Carbon.Audit/Producer/RequestContextMiddleware.cs
+++ b/Carbon.Audit/Producer/RequestContextMiddleware.cs
@@ -1,0 +1,59 @@
+using System.Security.Claims;
+using Carbon.Audit.Contracts;
+using Carbon.Audit.Producer.Http;
+using Microsoft.AspNetCore.Http;
+
+namespace Carbon.Audit.Producer;
+
+public sealed class RequestContextMiddleware
+{
+    private readonly RequestDelegate _next;
+
+    public RequestContextMiddleware(RequestDelegate next) => _next = next;
+
+    private static string? ClaimValue(ClaimsPrincipal principal, string claimType)
+        => principal.FindFirst(claimType)?.Value;
+
+    public async Task InvokeAsync(HttpContext http, RequestContext ctx)
+    {
+        var user = http.User;
+
+        ctx.UserId =
+            ClaimValue(user, ClaimTypes.NameIdentifier) ??
+            ClaimValue(user, "sub") ??
+            "anonymous";
+
+        ctx.UserName =
+            ClaimValue(user, ClaimTypes.Name) ??
+            ClaimValue(user, "name") ??
+            ClaimValue(user, "preferred_username") ??
+            "Unknown";
+
+        ctx.UserEmail =
+            ClaimValue(user, ClaimTypes.Email) ??
+            ClaimValue(user, "email") ??
+            string.Empty;
+
+        ctx.SessionId =
+            ClaimValue(user, "sid") ??
+            ClaimValue(user, "jti") ??  
+            string.Empty;
+
+        ctx.IpAddress = http.Connection.RemoteIpAddress?.ToString() ?? string.Empty;
+
+        var clientType = http.Request.Headers["X-Client-Type"].FirstOrDefault();
+        ctx.Source = clientType?.Equals("HMI", StringComparison.OrdinalIgnoreCase) == true
+            ? ClientSource.HMI
+            : ClientSource.Platform;
+        
+        var corr =
+            http.Request.Headers["X-CorrelationId"].FirstOrDefault()
+            ?? http.Request.Headers["X-Correlation-Id"].FirstOrDefault()
+            ?? http.Request.Headers["correlationId"].FirstOrDefault()
+            ?? http.Request.Headers["CorrelationId"].FirstOrDefault();
+
+        ctx.CorrelationId = string.IsNullOrWhiteSpace(corr) ? null : corr.Trim();
+
+        await _next(http);
+    }
+}

--- a/Carbon.Audit/ServiceCollectionExtensions.cs
+++ b/Carbon.Audit/ServiceCollectionExtensions.cs
@@ -15,6 +15,7 @@ public static class ServiceCollectionExtensions
     /// </summary>
     public static IServiceCollection AddCarbonAudit(this IServiceCollection services)
     {
+        services.AddHttpContextAccessor();
         services.AddScoped<RequestContext>();
         services.AddScoped<AuditInterceptor>();
         services.AddScoped<IAuditEventPublisher, RabbitMqAuditEventPublisher>();

--- a/Carbon.Audit/ServiceCollectionExtensions.cs
+++ b/Carbon.Audit/ServiceCollectionExtensions.cs
@@ -1,0 +1,33 @@
+using Carbon.Audit.Producer;
+using Carbon.Audit.Producer.Http;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Carbon.Audit;
+
+/// <summary>
+/// Extension methods for registering Carbon.Audit services into the DI container.
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers <see cref="RequestContext"/> as scoped and <see cref="AuditInterceptor"/> as scoped.
+    /// </summary>
+    public static IServiceCollection AddCarbonAudit(this IServiceCollection services)
+    {
+        services.AddScoped<RequestContext>();
+        services.AddScoped<AuditInterceptor>();
+        services.AddScoped<IAuditEventPublisher, RabbitMqAuditEventPublisher>();
+        return services;
+    }
+
+    /// <summary>
+    /// Adds the <see cref="RequestContextMiddleware"/> to the application pipeline.
+    /// </summary>
+    public static IApplicationBuilder UseCarbonAudit(this IApplicationBuilder app)
+    {
+        app.UseMiddleware<RequestContextMiddleware>();
+        return app;
+    }
+}
+


### PR DESCRIPTION
## What is it?
An audit infrastructure that automatically captures changes (Create/Update/Delete) on entities marked with `[Auditable]` during Entity Framework Core `SaveChanges`, enriches them with user/session context, and publishes them to RabbitMQ.

---

## Added Components

### Contracts
| Type | Description |
|---|---|
| `AuditEvent` | Root audit payload published to RabbitMQ |
| `FieldChange` | Before/after value of a single field |
| `AuditAction` | Enum: `Created`, `Updated`, `Deleted` |
| `ClientSource` | Enum representing the originating client type |
| `[Auditable]` | Marks an entity for audit tracking |
| `[AuditIgnore]` | Excludes a field from audit tracking |

### AuditInterceptor
- Extends EF Core `SaveChangesInterceptor`
- Reads `ChangeTracker` before and after save
- Extracts before/after snapshots and computes field-level diffs

### RequestContextMiddleware
- Extracts user info from JWT claims
- Captures `IP`, `X-Client-Type`, and `X-CorrelationId` headers

### RabbitMqAuditEventPublisher
- Fire-and-forget RabbitMQ publishing via MassTransit
- Falls back to structured JSON logging on failure

---

## Usage

### Mark Entities
```csharp
[Auditable]
public class Order
{
    public Guid Id { get; set; }
    public string Name { get; set; }

    [AuditIgnore]
    public string InternalNotes { get; set; }
}
```

---

## Notes
- Fully opt-in — no side effects unless explicitly enabled
- `[AuditIgnore]` fields are excluded from diff computation
- Publishing is fire-and-forget; audit failures do not affect the main transaction