### PR TITLE
fix: log ElasticSearch not-configured message via Serilog Debug level

### DIFF
--- a/Carbon.ElasticSearch/Carbon.ElasticSearch.csproj
+++ b/Carbon.ElasticSearch/Carbon.ElasticSearch.csproj
@@ -3,8 +3,10 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;net10.0</TargetFrameworks>
     <ProjectGuid>{7AEAD788-E78D-4825-9761-AEB2570DE3E0}</ProjectGuid>
-    <Version>3.10.0</Version>
+    <Version>3.10.1</Version>
     <Description>
+		3.10.1
+		- ElasticSearch not-configured message now logged via Serilog (Debug level) instead of Console.WriteLine.
 		3.10.0
 		- .NET 10 (net10.0) target framework added; existing targets preserved.
 		3.9.1
@@ -73,6 +75,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.4" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.4" />
+    <PackageReference Include="Serilog" Version="3.0.1" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
 	<PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.9" />
@@ -80,6 +83,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
+    <PackageReference Include="Serilog" Version="4.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Carbon.ElasticSearch/ElasticSettings.cs
+++ b/Carbon.ElasticSearch/ElasticSettings.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Elasticsearch.Net;
 using Microsoft.Extensions.Options;
 using Nest;
+using Serilog;
 using Carbon.ElasticSearch.Abstractions;
 
 namespace Carbon.ElasticSearch
@@ -42,7 +43,7 @@ namespace Carbon.ElasticSearch
 
             if (!settings.IsConfigured)
             {
-                Console.WriteLine("ElasticSearch is not configured. All ElasticSearch repository operations will be skipped.");
+                Log.Debug("ElasticSearch is not configured. All ElasticSearch repository operations will be skipped.");
                 return;
             }
 


### PR DESCRIPTION
Replaces Console.WriteLine with Log.Debug so the message follows the Serilog pipeline used elsewhere in the repo and only surfaces when the minimum log level is set to Debug, instead of always printing to console.